### PR TITLE
feat: プロジェクト基盤の構築

### DIFF
--- a/.claude/agents/plugin-reviewer.md
+++ b/.claude/agents/plugin-reviewer.md
@@ -1,0 +1,61 @@
+---
+name: plugin-reviewer
+description: Codex CLI を使ってプラグインの SKILL.md・agent .md の品質をレビューする。セルフレビューから呼び出される。
+tools: Read, Glob, Grep, Bash(codex *)
+model: sonnet
+---
+
+# プラグインレビュー
+
+指定されたプラグインの全ファイルを読み、Codex CLI による独立レビューを実施する。
+
+## 手順
+
+1. 対象プラグインの全ファイル（SKILL.md, agent .md, plugin.json）を Read で収集する
+2. レビュー観点を整理したプロンプトを構成する
+3. Codex CLI を実行してレビューを依頼する
+
+```bash
+codex -q "以下の観点でプラグインをレビューしてください。
+
+## レビュー観点
+
+### SKILL.md
+- 指示が明確で曖昧さがないか
+- 手順が論理的な順序で並んでいるか
+- MCP 推奨 + CLI フォールバックのパターンが守られているか（該当する場合）
+- references/ への参照が適切か（存在しないファイルを参照していないか）
+- description のトリガーキーワードが適切か（自動活性化に必要十分か）
+- disable-model-invocation の設定が適切か（ワークフロー/副作用 → true）
+
+### agent .md（subagent）
+- プロンプトのスコープが明確か（何をして何をしないかが分かるか）
+- tools の制限が妥当か（必要なツールが含まれ、不要なツールが除外されているか）
+- model の選択が適切か（重い処理には sonnet 以上、軽量なら haiku）
+- メイン会話から隔離する理由が妥当か
+
+### 全体整合性
+- plugin.json に記載された skills / agents と実ファイルが一致しているか
+- 命名規則（kebab-case、64文字以内）に従っているか
+- 日本語で記述されているか
+
+対象ディレクトリ: plugins/<plugin-name>/
+"
+```
+
+4. Codex の出力を以下の形式に整理して返却する
+
+## 出力形式
+
+```
+## レビュー結果: <plugin-name>（Codex レビュー）
+
+### 問題点
+- [重大] ...
+- [軽微] ...
+
+### 改善提案
+- ...
+
+### 総合判定: PASS / FAIL
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "Bash(git *)",
+      "Bash(gh issue *)",
+      "Bash(gh pr *)",
+      "Bash(ls *)",
+      "Bash(cat *)"
+    ]
+  }
+}

--- a/.claude/skills/issue-create/SKILL.md
+++ b/.claude/skills/issue-create/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: issue-create
+description: プラグイン開発用の Issue を作成する
+argument-hint: "[plugin-name]"
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep, Bash(gh issue *)
+---
+
+# Issue 作成
+
+プラグイン開発用の GitHub Issue を作成する。
+
+## 手順
+
+1. README.md を読み、対象プラグインの情報（名前、Tier、番号、スキル一覧）を取得する
+2. `.github/ISSUE_TEMPLATE/plugin-development.md` のテンプレートに沿って内容を構成する
+3. 概要はプラグインの説明文（README.md の各プラグイン冒頭の1行）を使う
+4. スキル一覧は README.md の表をそのまま転記する
+5. `gh issue create` で Issue を作成する
+
+## 実行コマンド例
+
+```bash
+gh issue create --title "feat: <plugin-name> プラグインの実装" --label "plugin" --body "..."
+```
+
+## 注意
+
+- $ARGUMENTS にプラグイン名が指定された場合はそのプラグインの Issue を作成する
+- 指定がない場合は未作成のプラグインを一覧表示し、ユーザーに選択させる
+- 既に同名の Issue が存在する場合は作成せず、既存 Issue の URL を表示する

--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: pr-create
+description: プラグイン実装の PR を作成する
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep, Bash(git *), Bash(gh pr *), Bash(gh issue *)
+---
+
+# PR 作成
+
+プラグイン実装の Pull Request を作成する。
+
+## 手順
+
+1. `git status` と `git diff main...HEAD` で変更内容を確認する
+2. 変更されたプラグインの plugin.json からプラグイン名を特定する
+3. `.github/PULL_REQUEST_TEMPLATE.md` のテンプレートに沿って PR 本文を構成する
+4. 対応 Issue を `gh issue list --label plugin` から特定し、`closes #N` を設定する
+5. プラグイン構成（スキル数、subagent 数）を plugin.json と実ファイルから集計する
+6. チェックリストは全項目を含める
+7. `gh pr create` で PR を作成する
+
+## 実行コマンド例
+
+```bash
+gh pr create --title "feat: <plugin-name> プラグインの実装" --body "..."
+```
+
+## 注意
+
+- PR 作成前に `/self-review` の実施を推奨する旨をユーザーに伝える
+- 未コミットの変更がある場合はコミットを促す
+- ブランチが main の場合は新しいブランチの作成を提案する

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: self-review
+description: PR 前のセルフレビューを実施する
+argument-hint: "[plugin-name]"
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep, Bash(git diff *), Task
+---
+
+# セルフレビュー
+
+PR を作成する前に、変更内容の品質を包括的にチェックする。
+
+## レビュー項目
+
+以下の順序でチェックを実施する。
+
+### 1. 構造検証（/validate-plugin 相当）
+
+- plugin.json の必須フィールド（name, version, description）が存在するか
+- skills/ 配下の各ディレクトリに SKILL.md が存在するか
+- SKILL.md の YAML frontmatter に name, description が定義されているか
+- plugin.json の agents に記載された .md ファイルが実在するか
+- plugin.json の hooks で指定されたファイルが実在するか（該当する場合）
+- hooks.json が正しい JSON であるか（該当する場合）
+
+### 2. CLAUDE.md 準拠チェック
+
+- MCP 推奨 + CLI フォールバックのパターンが守られているか
+- subagent 化の基準に該当する処理が subagent として実装されているか
+- スキルが単一責務（atomic）になっているか
+- 命名規則（kebab-case）に従っているか
+- 本文が日本語で記述されているか
+
+### 3. README.md との整合性チェック
+
+- README.md に記載されたスキル・subagent が全て実装されているか
+- 逆に README.md に未記載の実装がないか
+
+### 4. コード品質（plugin-reviewer subagent によるレビュー）
+
+`.claude/agents/plugin-reviewer.md` で定義された subagent を Task ツールで起動する。
+対象プラグインのパスを渡し、SKILL.md・agent .md の品質を独立してレビューさせる。
+subagent の結果を受け取り、このセルフレビューの「コード品質」セクションに統合する。
+
+## 出力
+
+チェック結果をカテゴリごとにまとめ、以下の形式で報告する。
+
+```
+## セルフレビュー結果
+
+### 構造検証: PASS / FAIL
+- (詳細)
+
+### CLAUDE.md 準拠: PASS / FAIL
+- (詳細)
+
+### README 整合性: PASS / FAIL
+- (詳細)
+
+### コード品質: PASS / FAIL
+- (詳細)
+
+### 総合判定: PR 作成可 / 要修正
+```
+
+## 注意
+
+- $ARGUMENTS にプラグイン名が指定された場合はそのプラグインのみレビューする
+- 指定がない場合は main ブランチとの差分から対象プラグインを自動検出する
+- FAIL がある場合は修正案を提示する

--- a/.claude/skills/validate-plugin/SKILL.md
+++ b/.claude/skills/validate-plugin/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: validate-plugin
+description: プラグインの構造が CLAUDE.md のルールに準拠しているか検証する
+argument-hint: "[plugin-name]"
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep
+---
+
+# プラグイン構造検証
+
+指定されたプラグインの構造を検証し、不備を報告する。
+
+## 検証項目
+
+### 1. plugin.json
+
+- ファイルが `.claude-plugin/plugin.json` に存在するか
+- 必須フィールドが定義されているか: name, version, description
+- version が semver 形式か
+- skills, agents, hooks のパスが正しいか
+
+### 2. スキル（skills/）
+
+- plugin.json の skills で指定されたディレクトリが存在するか
+- 各スキルディレクトリに SKILL.md が存在するか
+- SKILL.md の YAML frontmatter に name, description が定義されているか
+- name が kebab-case かつ 64 文字以内か
+- description にトリガーキーワードが含まれているか
+
+### 3. subagent（agents/）
+
+- plugin.json の agents に記載された .md ファイルが全て実在するか
+- 各 .md の YAML frontmatter に name, description, tools が定義されているか
+
+### 4. hooks（hooks/）
+
+- plugin.json に hooks が定義されている場合、hooks.json が存在するか
+- hooks.json が有効な JSON であるか
+- 参照されるスクリプトファイルが実在するか
+
+## 出力
+
+```
+## 構造検証結果: <plugin-name>
+
+- plugin.json: PASS / FAIL
+- skills: PASS / FAIL (N/N スキル)
+- agents: PASS / FAIL (N/N subagent)
+- hooks: PASS / SKIP
+
+総合: PASS / FAIL
+```
+
+## 注意
+
+- $ARGUMENTS にプラグイン名が指定された場合はそのプラグインを検証する
+- 指定がない場合は plugins/ 配下の全プラグインを検証する
+- FAIL の項目には具体的な修正方法を提示する

--- a/.github/ISSUE_TEMPLATE/plugin-development.md
+++ b/.github/ISSUE_TEMPLATE/plugin-development.md
@@ -1,0 +1,34 @@
+---
+name: プラグイン開発
+about: 新規プラグインの開発タスク
+labels: plugin
+---
+
+## 概要
+
+<!-- プラグインの目的を1-2行で -->
+
+## プラグイン情報
+
+- **プラグイン名**: `plugin-name`
+- **カテゴリ**: Tier 1 / Tier 2
+- **README 上の番号**: #N
+
+## スキル一覧
+
+<!-- README.md の表から転記 -->
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | | |
+| skill (manual) | | |
+| subagent | | |
+
+## 受け入れ条件
+
+- [ ] plugin.json が作成されている
+- [ ] 全スキルの SKILL.md が作成されている
+- [ ] subagent の agent .md が作成されている（該当する場合）
+- [ ] hooks.json が作成されている（該当する場合）
+- [ ] `/validate-plugin` が通る
+- [ ] README.md のプラグイン一覧と整合している

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## 対応 Issue
+
+closes #
+
+## 変更内容
+
+<!-- 何を実装したか簡潔に -->
+
+## プラグイン構成
+
+- **プラグイン名**: `plugin-name`
+- **スキル数**: N（うち manual: N）
+- **subagent 数**: N
+
+## チェックリスト
+
+- [ ] `/validate-plugin` が通る
+- [ ] `/self-review` を実施済み
+- [ ] CLAUDE.md の必須ルールに準拠している
+- [ ] README.md と整合している

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+iOS チーム開発を包括的にサポートする Claude Code プラグインストア。
+
+## ロール
+
+あなたは iOS 向け Claude Code プラグインの開発者です。SwiftUI + MVVM アーキテクチャを前提としたチーム開発の品質向上・効率化を目的としたスキル・subagent を設計・実装します。
+
+## 必須ルール
+
+### プラグイン構造
+
+各プラグインは以下の構造に従う。
+
+```
+plugin-name/
+├── .claude-plugin/
+│   └── plugin.json          # name, version, description, skills, agents, hooks
+├── skills/
+│   └── skill-name/
+│       ├── SKILL.md          # YAML frontmatter (name, description) + 指示本文
+│       └── references/       # 詳細仕様・パターン例（Progressive Disclosure）
+├── agents/
+│   └── agent-name.md         # subagent 定義（YAML frontmatter + プロンプト）
+└── hooks/
+    └── hooks.json            # イベントフック定義
+```
+
+### MCP 推奨 + CLI フォールバック
+
+- スキル内では MCP ツールの利用を優先する
+- MCP が利用できない場合は CLI（xcodebuild, swift, gh 等）にフォールバックする
+- subagent は MCP にアクセスできないため、常に CLI で実装する
+
+### subagent 化の基準
+
+以下のいずれかに該当する処理は subagent として隔離する。
+
+- プロジェクト全体を走査する処理（lint 全体スキャン、依存分析等）
+- ビルド・テスト実行のようにログ出力が膨大な処理
+- 実行時間が長くメイン会話のコンテキストを圧迫する処理
+
+### スキル設計
+
+- 1 スキル 1 責務（atomic）に設計する
+- 複数スキルの組み合わせもワークフロー skill として定義する（commands/ は使わない）
+- description にトリガーキーワードを含め、自動活性化を促す
+- 詳細な仕様や参照情報は references/ に分離する（Progressive Disclosure）
+
+### スキルの起動制御（disable-model-invocation）
+
+- 読み取り・分析・提案系のスキル → `false`（デフォルト）。Claude が文脈に応じて自動発火
+- 複数スキルを組み合わせるワークフロー → `true`。ユーザーが `/skill-name` で明示的に実行
+- 外部に副作用がある操作（issue 作成、PR 作成、アップロード等） → `true`
+
+## ガイドライン
+
+### 命名規則
+
+- プラグイン名: kebab-case（例: `code-review-assist`）
+- スキル名: kebab-case、最大 64 文字（例: `pr-diff-review`）
+- subagent 名: kebab-case、役割を明示（例: `review-analyzer`）
+
+### 記述言語
+
+- SKILL.md, agent .md の本文は日本語で記述する
+- plugin.json の description も日本語で記述する
+- コード例・コマンド例は英語のまま記述する
+
+### 推奨 MCP サーバー
+
+| MCP サーバー | 用途 |
+|---|---|
+| XcodeBuildMCP | ビルド・テスト実行・シミュレータ操作・デバッグ |
+| xcodeproj-mcp-server | プロジェクトファイル操作・ターゲット管理・SPM 依存管理 |
+
+## コマンド
+
+```bash
+# プラグインのインストール確認
+/plugin list
+
+# マーケットプレイスからの追加
+/plugin marketplace add inoue0124/ios-claude-plugins
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,243 @@
+# iOS Claude Plugins
+
+iOS チーム開発を包括的にサポートする Claude Code プラグインストア。
+
+コードレビュー、規約統一、テスト文化の定着、オンボーディングといったチーム開発の課題を解決し、AI によるコード品質の向上を実現する。
+
+## 設計方針
+
+- **スキルは細粒度** — 単一責務の atomic なスキルとして設計
+- **全て skills で統一** — ワークフロー（複数スキルの組み合わせ）も skill として定義。`disable-model-invocation: true` でユーザー起動のみに制限
+- **重い処理は subagent 化** — ビルド・テスト実行・全体スキャンなどコンテキストを圧迫する処理は隔離実行
+- **MCP 推奨 + CLI フォールバック** — MCP サーバーの利用を推奨。MCP が利用できない環境では CLI（xcodebuild, swift, gh 等）にフォールバック
+- **SwiftUI + MVVM** — アーキテクチャ規約は SwiftUI + MVVM をベースに設計
+
+## プラグイン一覧
+
+### スキルの種別
+
+| 表記 | 意味 | `disable-model-invocation` |
+|---|---|---|
+| skill | Claude が文脈に応じて自動で発火する | `false`（デフォルト） |
+| skill (manual) | ユーザーが `/skill-name` で明示的に実行する。ワークフローや副作用を伴う操作 | `true` |
+
+### Tier 1: 日常の開発サイクルで毎日使うもの
+
+#### 1. `ios-architecture` — アーキテクチャガード
+
+MVVM パターンの構造チェック・レイヤー間の依存方向検査・DI パターンの提案を行う。
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | mvvm-check | View / ViewModel / Model 分離の検査 |
+| skill | layer-dependency-check | レイヤー間の依存方向チェック |
+| skill | di-pattern-suggest | Dependency Injection パターンの提案 |
+| skill | protocol-oriented-check | Protocol 指向設計の推奨・改善提案 |
+| subagent | architecture-scanner | 全モジュールの依存関係分析 |
+| skill (manual) | arch-audit | アーキテクチャ全体監査ワークフロー |
+
+#### 2. `team-conventions` — 規約エンフォーサー
+
+チームのコーディング規約・命名規則・ブランチ運用ルールを自動で検査・強制する。
+hooks でコード生成前に規約を注入し、最初から規約通りに書く。
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | naming-check | Swift 命名規則（API Design Guidelines 準拠）チェック |
+| skill | file-structure-check | ファイル配置がチーム規約に沿っているか検査 |
+| skill | commit-message-lint | コミットメッセージ形式チェック |
+| skill | branch-naming-check | ブランチ命名規則の検証 |
+| skill | pr-description-gen | PR テンプレートに基づく説明文の自動生成 |
+| subagent | convention-scanner | プロジェクト全体の規約準拠スキャン |
+| skill (manual) | convention-check | 変更ファイルに対する規約チェック一括ワークフロー |
+| hooks | UserPromptSubmit | コード生成時に規約をコンテキスト注入 |
+
+#### 3. `swift-code-quality` — コード品質ガード
+
+SwiftLint / SwiftFormat による静的解析と軽量な構文チェックで、フルビルドなしにコード品質を担保する。
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | swift-lint | SwiftLint 実行 + 違反の自動修正 |
+| skill | swift-format | SwiftFormat 実行 |
+| skill | syntax-typecheck | `swiftc -typecheck` による軽量構文チェック |
+| skill | complexity-analysis | 循環的複雑度・関数行数の分析 |
+| skill | dead-code-detect | 未使用コード・未使用 import の検出 |
+| skill | type-safety-check | force unwrap / force cast の検出 + 安全な書き換え提案 |
+| subagent | lint-scanner | プロジェクト全体の lint 一括スキャン |
+| skill (manual) | quality-check | lint + format + typecheck 一括ワークフロー |
+
+#### 4. `swift-testing` — テスト生成・実行
+
+ユニットテスト・UI テストの生成からテスト実行・カバレッジ分析まで、テストのライフサイクル全体をサポートする。
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | unit-test-gen | 対象コードからユニットテスト生成 |
+| skill | ui-test-gen | SwiftUI 画面から XCUITest 生成 |
+| skill | mock-gen | Protocol 準拠のモック / スタブ自動生成 |
+| skill | test-pattern-suggest | テスト対象に適切なテストパターンを提案 |
+| skill | coverage-gap-detect | テスト未カバーのパスを特定 |
+| subagent | test-runner | テスト実行（xcodebuild test）+ 結果パース |
+| subagent | coverage-reporter | カバレッジ収集 + レポート生成 |
+| skill (manual) | test-gen | テスト生成 → 実行 → カバレッジ一括ワークフロー |
+
+#### 5. `github-workflow` — Issue / PR 管理
+
+構造化された issue 作成と、差分解析に基づく PR 作成でチームのタスク管理を標準化する。
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill (manual) | issue-create | 構造化された issue 作成 |
+| skill | issue-triage | ラベル・優先度・アサイン提案 |
+| skill (manual) | pr-create | 差分解析 + 説明文生成 + PR 作成 |
+| skill | pr-checklist | セルフレビューチェックリスト |
+| skill (manual) | pr-link-issues | PR と issue の紐付け |
+
+#### 6. `code-review-assist` — コードレビュー支援
+
+PR の差分を分析し、レビューコメントの生成・アーキテクチャ適合チェック・影響範囲の特定を行う。
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | pr-diff-review | PR 差分を読んでレビューコメント生成 |
+| skill | architecture-conformance | 変更が MVVM / レイヤー規約に沿っているか検査 |
+| skill | impact-analysis | 変更の影響範囲を特定（依存先・呼び出し元） |
+| skill | review-comment-draft | 指摘コメントを「理由 + 提案」形式で下書き |
+| subagent | review-analyzer | PR 全体を包括分析（大規模差分の隔離実行） |
+| skill (manual) | pr-review | 上記を組み合わせた包括レビューワークフロー |
+
+### Tier 2: プロジェクト構築・配信フェーズで使うもの
+
+#### 7. `ios-onboarding` — オンボーディング支援
+
+プロジェクト構造の自動解説・用語集生成・最近の変更要約で、新メンバーの立ち上がりを加速する。
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | codebase-overview | プロジェクト構造の概要を自動生成 |
+| skill | module-guide | 各 SPM モジュールの責務と依存関係を解説 |
+| skill | architecture-map | アーキテクチャ構造をテキスト図で可視化 |
+| skill | glossary-gen | プロジェクト固有の用語集を生成 |
+| skill | recent-changes-summary | 直近のコミットから「今何が起きているか」を要約 |
+| subagent | codebase-analyzer | プロジェクト全体を走査して構造分析 |
+| skill (manual) | onboard | 新メンバー向けガイド一式生成ワークフロー |
+
+#### 8. `feature-module-gen` — Feature Module 生成
+
+SwiftUI + MVVM の Feature Module 雛形を一式生成し、SPM パッケージへの組み込みまで行う。新機能開発の立ち上げ。
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | feature-scaffold | Feature Module 雛形（View / ViewModel / Repository / DI）一式生成 |
+| skill | view-gen | SwiftUI View 生成（チーム規約準拠） |
+| skill | viewmodel-gen | ViewModel 生成（Input / Output, @Published 等） |
+| skill | repository-gen | Repository + Protocol 生成 |
+| skill | usecase-gen | UseCase 生成 |
+| subagent | module-generator | モジュール一式生成 + Package.swift 更新 + 構文検証 |
+| skill (manual) | new-feature | 対話的に Feature Module 一式生成ワークフロー |
+
+#### 9. `ios-distribution` — TestFlight 配信・署名
+
+アーカイブビルドから TestFlight アップロードまでの配信フローを自動化する。
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | signing-check | 署名・プロビジョニング確認 |
+| skill (manual) | build-archive | IPA 生成 |
+| skill (manual) | testflight-upload | archive + upload（xcodebuild + xcrun altool） |
+| subagent | archive-runner | アーカイブ + アップロード（隔離実行） |
+
+## subagent 一覧
+
+| subagent | 所属プラグイン | 隔離理由 |
+|---|---|---|
+| architecture-scanner | ios-architecture | 依存関係の全体分析 |
+| convention-scanner | team-conventions | プロジェクト全体の規約スキャン |
+| lint-scanner | swift-code-quality | 全体 lint 一括スキャン |
+| test-runner | swift-testing | テスト実行 + ログパース |
+| coverage-reporter | swift-testing | カバレッジ収集 + レポート |
+| review-analyzer | code-review-assist | 大規模 PR 差分の全体分析 |
+| codebase-analyzer | ios-onboarding | 全体構造の走査 + 分析 |
+| module-generator | feature-module-gen | モジュール一式生成 + 構文検証 |
+| archive-runner | ios-distribution | アーカイブ + アップロード |
+
+## ディレクトリ構成
+
+```
+ios-claude-plugins/
+├── .claude-plugin/
+│   └── marketplace.json          # マーケットプレイス定義
+├── plugins/
+│   ├── ios-architecture/          # 1. 設計ガード
+│   │   ├── .claude-plugin/
+│   │   │   └── plugin.json
+│   │   ├── skills/
+│   │   │   ├── mvvm-check/
+│   │   │   │   └── SKILL.md
+│   │   │   ├── layer-dependency-check/
+│   │   │   ├── di-pattern-suggest/
+│   │   │   ├── protocol-oriented-check/
+│   │   │   └── arch-audit/        # workflow (manual)
+│   │   └── agents/
+│   │       └── architecture-scanner.md
+│   ├── team-conventions/          # 2. 規約エンフォース
+│   ├── swift-code-quality/        # 3. 品質チェック
+│   ├── swift-testing/             # 4. テスト
+│   ├── github-workflow/           # 5. Issue / PR
+│   ├── code-review-assist/        # 6. レビュー
+│   ├── ios-onboarding/            # 7. オンボーディング
+│   ├── feature-module-gen/        # 8. モジュール生成
+│   └── ios-distribution/          # 9. 配信
+├── CLAUDE.md
+└── README.md
+```
+
+## インストール
+
+### マーケットプレイスから一括追加
+
+```bash
+/plugin marketplace add inoue0124/ios-claude-plugins
+```
+
+### 個別プラグインのインストール
+
+```bash
+/plugin install ios-architecture
+/plugin install team-conventions
+/plugin install swift-code-quality
+/plugin install swift-testing
+/plugin install github-workflow
+/plugin install code-review-assist
+/plugin install ios-onboarding
+/plugin install feature-module-gen
+/plugin install ios-distribution
+```
+
+### 推奨 MCP サーバー
+
+本プラグインストアは以下の MCP サーバーとの併用を推奨する。MCP が利用できない環境では各スキルが CLI にフォールバックする。
+
+| MCP サーバー | 用途 | インストール |
+|---|---|---|
+| [XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP) | ビルド・テスト実行・シミュレータ操作・デバッグ・UI 自動化 | `claude mcp add XcodeBuildMCP -- npx -y xcodebuildmcp@latest mcp` |
+| [xcodeproj-mcp-server](https://github.com/giginet/xcodeproj-mcp-server) | Xcode プロジェクトファイル操作（ファイル追加・ターゲット管理・ビルド設定・SPM 依存管理） | `claude mcp add xcodeproj -- docker run --pull=always --rm -i -v $PWD:/workspace ghcr.io/giginet/xcodeproj-mcp-server:latest /workspace` |
+
+**XcodeBuildMCP** はビルド・テスト・シミュレータといった「実行系」を、**xcodeproj-mcp-server** はファイル追加・ターゲット作成・ビルド設定変更といった「プロジェクト構造操作」を担う。両方を導入することで、プラグインの全機能を最大限に活用できる。
+
+### 前提条件
+
+| ツール | 用途 | 必須 |
+|---|---|---|
+| Xcode | ビルド・テスト実行（xcodebuild） | 必須 |
+| SwiftLint | コード品質チェック | 必須 |
+| SwiftFormat | コードフォーマット | 必須 |
+| gh CLI | GitHub issue / PR 操作 | 必須 |
+| Node.js 18+ | XcodeBuildMCP の実行 | 推奨 |
+| Docker | xcodeproj-mcp-server の実行 | 推奨 |
+| xcrun altool | TestFlight アップロード | ios-distribution 利用時 |
+
+## ライセンス
+
+MIT


### PR DESCRIPTION
## 対応 Issue

closes #1

## 変更内容

iOS 開発向け Claude Code プラグインストアのプロジェクト基盤を構築。README.md、CLAUDE.md、開発ワークフロー用スキル・サブエージェント、GitHub テンプレートを追加。

## プラグイン構成

本 PR はプラグイン実装ではなく、プロジェクト基盤の構築です。

- **README.md**: 9 プラグインの設計（Tier 1: 6, Tier 2: 3）・インストール手順・MCP サーバー推奨
- **CLAUDE.md**: プラグイン構造ルール・命名規則・設計ガイドライン（~85行）
- **開発スキル**: issue-create, pr-create, self-review, validate-plugin
- **サブエージェント**: plugin-reviewer（Codex CLI 連携）
- **GitHub テンプレート**: Issue（plugin-development）/ PR

## チェックリスト

- [x] `/validate-plugin` が通る（本 PR はプラグイン実装ではないため N/A）
- [x] `/self-review` を実施済み
- [x] CLAUDE.md の必須ルールに準拠している
- [x] README.md と整合している

🤖 Generated with [Claude Code](https://claude.com/claude-code)