### PR TITLE
fix: スキルの frontmatter 修正と implement-plugin スキルの追加

### DIFF
--- a/.claude/skills/implement-plugin/SKILL.md
+++ b/.claude/skills/implement-plugin/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: implement-plugin
+description: Issue に基づいてプラグインのファイル一式を実装する
+argument-hint: "[plugin-name]"
+disable-model-invocation: true
+---
+
+# プラグイン実装
+
+Issue の内容に基づき、プラグインのディレクトリ構造とファイル一式を生成する。
+
+## 手順
+
+1. $ARGUMENTS のプラグイン名に対応する Issue を `gh issue view` で取得する
+2. README.md から対象プラグインのスキル・subagent 一覧を確認する
+3. CLAUDE.md からプラグイン構造ルール・設計ガイドラインを確認する
+4. 各ファイルの作成ルールは → **references/IMPLEMENTATION_GUIDE.md** を参照
+5. `plugins/<plugin-name>/` 配下にファイル一式を生成する
+6. 実装完了後、`/validate-plugin <plugin-name>` の実行を推奨する旨をユーザーに伝える
+
+## 注意
+
+- $ARGUMENTS にプラグイン名が指定されない場合は `gh issue list --label plugin` から候補を表示する
+- 既にファイルが存在する場合は上書きせず、差分を確認してから更新する

--- a/.claude/skills/implement-plugin/references/IMPLEMENTATION_GUIDE.md
+++ b/.claude/skills/implement-plugin/references/IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,98 @@
+# プラグイン実装ガイド
+
+## ディレクトリ構造
+
+```
+plugins/<plugin-name>/
+├── .claude-plugin/
+│   └── plugin.json
+├── skills/
+│   └── <skill-name>/
+│       ├── SKILL.md
+│       └── references/       # 必要に応じて
+├── agents/
+│   └── <agent-name>.md       # subagent がある場合
+└── hooks/
+    └── hooks.json             # hooks がある場合
+```
+
+## plugin.json
+
+```json
+{
+  "name": "<plugin-name>",
+  "version": "0.1.0",
+  "description": "<日本語の説明>",
+  "skills": ["skills/<skill-name>"],
+  "agents": ["agents/<agent-name>.md"],
+  "hooks": ["hooks/hooks.json"]
+}
+```
+
+- skills, agents, hooks は実際に存在するもののみ列挙する
+- description は README.md のプラグイン説明文を使う
+
+## SKILL.md
+
+### frontmatter
+
+```yaml
+---
+name: <skill-name>
+description: <トリガーキーワードを含む説明文>
+---
+```
+
+- `name`, `description` は必須
+- 読み取り・分析・提案系 → `disable-model-invocation` を省略（デフォルト false）
+- ワークフロー・副作用系 → `disable-model-invocation: true` を明記
+- `argument-hint` はユーザー引数を受け取るスキルのみ
+
+### 本文の書き方
+
+- 日本語で記述する。コード例・コマンド例は英語のまま
+- MCP 推奨 + CLI フォールバックのパターンを記述する（該当する場合）
+- description にはトリガーキーワードを含め、自動活性化を促す
+- 詳細な仕様やパターン例は references/ に分離する（Progressive Disclosure）
+
+### disable-model-invocation の判断基準
+
+| スキルの性質 | 設定 | 理由 |
+|---|---|---|
+| 読み取り・分析・提案 | 省略（false） | Claude が文脈に応じて自動発火 |
+| 複数スキルの組み合わせワークフロー | `true` | ユーザーが `/skill-name` で明示実行 |
+| 外部に副作用がある操作 | `true` | 意図しない実行を防止 |
+
+## agent.md（subagent）
+
+### frontmatter
+
+```yaml
+---
+name: <agent-name>
+description: <説明文>
+tools: <ツールリスト>
+model: sonnet
+---
+```
+
+- `name`, `description`, `tools`, `model` は必須
+- MCP にアクセスできないため CLI ツールのみ指定する
+- model は処理の重さに応じて選択（全体スキャン系 → sonnet、軽量処理 → haiku）
+
+### 本文の書き方
+
+- プロンプトにスコープ（何をして何をしないか）を明確に記述する
+- 出力形式を指定して結果をパースしやすくする
+
+## hooks.json（hooks がある場合）
+
+- 有効な JSON 形式で記述する
+- 参照するスクリプトファイルも合わせて作成する
+
+## 品質基準
+
+- CLAUDE.md の必須ルールに全て準拠していること
+- README.md のスキル一覧と実ファイルが一致していること
+- 全ファイルが kebab-case・64 文字以内の命名規則に従っていること
+- `/validate-plugin` が通る状態であること

--- a/.claude/skills/issue-create/SKILL.md
+++ b/.claude/skills/issue-create/SKILL.md
@@ -3,7 +3,6 @@ name: issue-create
 description: プラグイン開発用の Issue を作成する
 argument-hint: "[plugin-name]"
 disable-model-invocation: true
-allowed-tools: Read, Glob, Grep, Bash(gh issue *)
 ---
 
 # Issue 作成

--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -2,7 +2,6 @@
 name: pr-create
 description: プラグイン実装の PR を作成する
 disable-model-invocation: true
-allowed-tools: Read, Glob, Grep, Bash(git *), Bash(gh pr *), Bash(gh issue *)
 ---
 
 # PR 作成

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -3,7 +3,6 @@ name: self-review
 description: PR 前のセルフレビューを実施する
 argument-hint: "[plugin-name]"
 disable-model-invocation: true
-allowed-tools: Read, Glob, Grep, Bash(git diff *), Task
 ---
 
 # セルフレビュー

--- a/.claude/skills/validate-plugin/SKILL.md
+++ b/.claude/skills/validate-plugin/SKILL.md
@@ -3,7 +3,6 @@ name: validate-plugin
 description: プラグインの構造が CLAUDE.md のルールに準拠しているか検証する
 argument-hint: "[plugin-name]"
 disable-model-invocation: true
-allowed-tools: Read, Glob, Grep
 ---
 
 # プラグイン構造検証


### PR DESCRIPTION
## 対応 Issue

closes #12

## 変更内容

- 全スキル（4ファイル）の frontmatter から非サポート属性 `allowed-tools` を削除
- プラグイン実装用の `/implement-plugin` スキルを追加
- 詳細な実装ガイドを `references/IMPLEMENTATION_GUIDE.md` に分離（Progressive Disclosure）

## チェックリスト

- [x] IDE の diagnostics で警告が出ないこと
- [x] CLAUDE.md の必須ルールに準拠している
- [x] README.md と整合している

🤖 Generated with [Claude Code](https://claude.com/claude-code)