### PR TITLE
fix: スキル frontmatter の allowed-tools 削除と disable-model-invocation 調整

### DIFF
--- a/.claude/skills/issue-create/SKILL.md
+++ b/.claude/skills/issue-create/SKILL.md
@@ -3,7 +3,6 @@ name: issue-create
 description: プラグイン開発用の Issue を作成する
 argument-hint: "[plugin-name]"
 disable-model-invocation: true
-allowed-tools: Read, Glob, Grep, Bash(gh issue *)
 ---
 
 # Issue 作成

--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: pr-create
 description: プラグイン実装の PR を作成する
-disable-model-invocation: true
-allowed-tools: Read, Glob, Grep, Bash(git *), Bash(gh pr *), Bash(gh issue *)
 ---
 
 # PR 作成

--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -2,8 +2,6 @@
 name: self-review
 description: PR 前のセルフレビューを実施する
 argument-hint: "[plugin-name]"
-disable-model-invocation: true
-allowed-tools: Read, Glob, Grep, Bash(git diff *), Task
 ---
 
 # セルフレビュー

--- a/.claude/skills/validate-plugin/SKILL.md
+++ b/.claude/skills/validate-plugin/SKILL.md
@@ -2,8 +2,6 @@
 name: validate-plugin
 description: プラグインの構造が CLAUDE.md のルールに準拠しているか検証する
 argument-hint: "[plugin-name]"
-disable-model-invocation: true
-allowed-tools: Read, Glob, Grep
 ---
 
 # プラグイン構造検証


### PR DESCRIPTION
## Summary
- 全スキルから非サポート属性 `allowed-tools` を削除
- `pr-create`・`self-review`・`validate-plugin` から `disable-model-invocation: true` を削除し、`implement-plugin` ワークフローが自動チェーンできるようにする
- `issue-create` は外部副作用があるため `disable-model-invocation: true` を維持

## Test plan
- [ ] `implement-plugin` ワークフローで validate → self-review → pr-create が自動実行されることを確認
- [ ] `issue-create` は `/issue-create` で明示的に呼び出さないと発火しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)