### PR TITLE
feat: ios-distribution プラグインの実装

### DIFF
--- a/plugins/ios-distribution/.claude-plugin/plugin.json
+++ b/plugins/ios-distribution/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "ios-distribution",
+  "version": "0.1.0",
+  "description": "アーカイブビルドから TestFlight アップロードまでの配信フローを自動化する",
+  "skills": [
+    "skills/signing-check",
+    "skills/build-archive",
+    "skills/testflight-upload"
+  ],
+  "agents": [
+    "agents/archive-runner.md"
+  ]
+}

--- a/plugins/ios-distribution/agents/archive-runner.md
+++ b/plugins/ios-distribution/agents/archive-runner.md
@@ -1,0 +1,128 @@
+---
+name: archive-runner
+description: Xcode プロジェクトのアーカイブビルド・IPA エクスポート・TestFlight アップロードを隔離実行する
+tools: Bash
+model: sonnet
+---
+
+# アーカイブ + アップロード実行エージェント
+
+Xcode プロジェクトのアーカイブビルドから TestFlight アップロードまでを隔離環境で実行する。
+ビルドログが膨大になるため、メイン会話のコンテキストを圧迫しないよう subagent として分離する。
+
+## スコープ
+
+### やること
+
+- `xcodebuild archive` でアーカイブビルドを実行する
+- `xcodebuild -exportArchive` で IPA をエクスポートする
+- `xcrun altool --upload-app` で TestFlight にアップロードする（指示された場合）
+- ビルドエラー・アップロードエラーのログをパースし、原因を特定する
+- 結果のサマリーを返す
+
+### やらないこと
+
+- プロジェクト設定の変更は行わない
+- 署名・プロビジョニングの設定変更は行わない
+- ExportOptions.plist の自動生成は行わない（テンプレート提案はスキル側が担当）
+
+## 実行手順
+
+### 1. 環境確認
+
+```bash
+# Xcode のバージョン確認
+xcodebuild -version
+
+# 利用可能なスキーム一覧（プロジェクト指定がない場合）
+xcodebuild -list -project <project>.xcodeproj
+# または
+xcodebuild -list -workspace <workspace>.xcworkspace
+```
+
+### 2. アーカイブビルド
+
+```bash
+xcodebuild archive \
+  -project <project>.xcodeproj \
+  -scheme <scheme> \
+  -archivePath build/<scheme>.xcarchive \
+  -configuration Release \
+  -destination "generic/platform=iOS" \
+  2>&1 | tail -20
+```
+
+ワークスペース使用時は `-project` を `-workspace` に置き換える。
+
+ビルドログが膨大になるため `tail -20` で末尾のみ取得する。エラー発生時はログ全体から `error:` 行を抽出する。
+
+```bash
+# エラー行の抽出
+xcodebuild archive ... 2>&1 | grep -E "^.*(error|warning):.*$" | head -50
+```
+
+### 3. IPA エクスポート
+
+```bash
+xcodebuild -exportArchive \
+  -archivePath build/<scheme>.xcarchive \
+  -exportPath build/ipa \
+  -exportOptionsPlist ExportOptions.plist \
+  2>&1 | tail -10
+```
+
+### 4. IPA ファイルの確認
+
+```bash
+# IPA ファイルの存在確認
+ls -la build/ipa/*.ipa
+
+# ファイルサイズの確認
+du -sh build/ipa/*.ipa
+```
+
+### 5. TestFlight アップロード（指示された場合のみ）
+
+```bash
+xcrun altool --upload-app \
+  --type ios \
+  --file build/ipa/<app-name>.ipa \
+  --apiKey <api-key> \
+  --apiIssuer <issuer-id> \
+  2>&1
+```
+
+エラー発生時はエラーコードから原因を特定する。
+
+| エラーコード | 原因 | 対処 |
+|---|---|---|
+| -22421 | 認証失敗 | API キー・Issuer ID を確認 |
+| -22020 | IPA が無効 | アーカイブ設定・ExportOptions.plist を確認 |
+| -22007 | アプリ情報不足 | App Store Connect でアプリが登録済みか確認 |
+
+## 出力形式
+
+```
+## archive-runner 実行結果
+
+### 環境
+- Xcode: <バージョン>
+- スキーム: <スキーム名>
+- 構成: Release
+
+### アーカイブ: SUCCESS / FAILURE
+- パス: build/<scheme>.xcarchive
+- ログ: <末尾 5 行>
+
+### IPA エクスポート: SUCCESS / FAILURE
+- パス: build/ipa/<app-name>.ipa
+- サイズ: N MB
+
+### TestFlight アップロード: SUCCESS / FAILURE / SKIPPED
+- 結果: <altool の出力>
+
+### エラー（該当する場合）
+- エラー種別: ビルドエラー / エクスポートエラー / アップロードエラー
+- 詳細: <エラーメッセージ>
+- 原因推定: <原因の分析>
+```

--- a/plugins/ios-distribution/skills/build-archive/SKILL.md
+++ b/plugins/ios-distribution/skills/build-archive/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: build-archive
+description: Xcode プロジェクトをアーカイブし IPA ファイルを生成する。archive-runner サブエージェントに処理を委譲する
+disable-model-invocation: true
+---
+
+# IPA 生成（アーカイブビルド）
+
+> このスキルは `/build-archive` で明示的に実行します。自動活性化されません。
+
+Xcode プロジェクトをアーカイブし、IPA ファイルを生成する。
+ビルドログが膨大になるため、実際のアーカイブ処理は archive-runner サブエージェントに委譲する。
+
+## ツール使用方針
+
+- アーカイブビルドは XcodeBuildMCP の利用を優先する
+- MCP が利用できない場合は `xcodebuild` CLI にフォールバックする
+- ビルドログが膨大になるため、archive-runner サブエージェントに処理を委譲する
+
+### MCP 利用時
+
+- XcodeBuildMCP の `xcodebuild_archive` ツールでアーカイブを実行する
+- XcodeBuildMCP の `xcodebuild_export` ツールで IPA をエクスポートする
+
+### CLI フォールバック（archive-runner が実行）
+
+以下のコマンドを使用する。
+
+```bash
+# アーカイブ
+xcodebuild archive \
+  -project <project>.xcodeproj \
+  -scheme <scheme> \
+  -archivePath build/<scheme>.xcarchive \
+  -configuration Release \
+  -destination "generic/platform=iOS"
+
+# ワークスペース使用時
+xcodebuild archive \
+  -workspace <workspace>.xcworkspace \
+  -scheme <scheme> \
+  -archivePath build/<scheme>.xcarchive \
+  -configuration Release \
+  -destination "generic/platform=iOS"
+
+# IPA エクスポート
+xcodebuild -exportArchive \
+  -archivePath build/<scheme>.xcarchive \
+  -exportPath build/ipa \
+  -exportOptionsPlist ExportOptions.plist
+```
+
+## 実行フロー
+
+### Step 1: 事前確認
+
+- プロジェクトファイル（`.xcodeproj` / `.xcworkspace`）の存在確認
+- スキーム名の確認（引数またはプロジェクトから自動取得）
+- ExportOptions.plist の存在確認（なければ生成を提案）
+
+### Step 2: ExportOptions.plist の準備
+
+ExportOptions.plist が存在しない場合、以下のテンプレートを提案する。
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>teamID</key>
+    <string>YOUR_TEAM_ID</string>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>compileBitcode</key>
+    <false/>
+</dict>
+</plist>
+```
+
+### Step 3: アーカイブ実行
+
+archive-runner サブエージェントにアーカイブとエクスポートを委譲する。
+
+### Step 4: 結果確認
+
+- `.xcarchive` の生成を確認する
+- IPA ファイルの生成を確認する
+- エラーがあれば原因を分析して報告する
+
+## 出力
+
+```
+## アーカイブ結果
+
+### 設定
+- プロジェクト: <プロジェクト名>
+- スキーム: <スキーム名>
+- 構成: Release
+
+### 結果: SUCCESS / FAILURE
+- アーカイブ: <パス>.xcarchive (SUCCESS / FAILURE)
+- IPA: <パス>.ipa (SUCCESS / FAILURE)
+- ファイルサイズ: N MB
+
+### エラー（該当する場合）
+- <エラー内容>
+- [提案] <修正案>
+```
+
+## 引数
+
+- `--scheme <name>`: アーカイブ対象のスキーム名（省略時はプロジェクトから自動取得）
+- `--project <path>`: プロジェクトファイルのパス（省略時はカレントディレクトリを検索）
+- `--workspace <path>`: ワークスペースファイルのパス
+- `--export-options <path>`: ExportOptions.plist のパス（省略時は `ExportOptions.plist`）

--- a/plugins/ios-distribution/skills/signing-check/SKILL.md
+++ b/plugins/ios-distribution/skills/signing-check/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: signing-check
+description: コード署名・プロビジョニングプロファイルの設定を確認する。「署名」「プロビジョニング」「signing」「provisioning」「証明書」「certificate」「コード署名」で自動適用。
+---
+
+# 署名・プロビジョニング確認
+
+指定されたプロジェクトまたはターゲットに対し、コード署名とプロビジョニングプロファイルの設定が正しく構成されているかを確認する。
+
+## ツール使用方針
+
+- プロジェクト設定の読み取りは XcodeBuildMCP / xcodeproj-mcp-server の利用を優先する
+- MCP が利用できない場合は CLI にフォールバックする
+
+### MCP 利用時
+
+- xcodeproj-mcp-server でビルド設定（`CODE_SIGN_IDENTITY`, `PROVISIONING_PROFILE_SPECIFIER`, `DEVELOPMENT_TEAM` 等）を取得する
+- XcodeBuildMCP で `xcodebuild -showBuildSettings` 相当の情報を取得する
+
+### CLI フォールバック
+
+以下のコマンドを使用する。
+
+```bash
+# ビルド設定の確認
+xcodebuild -showBuildSettings -project <project>.xcodeproj -scheme <scheme> | grep -E "(CODE_SIGN|PROVISIONING|DEVELOPMENT_TEAM)"
+
+# ワークスペース使用時
+xcodebuild -showBuildSettings -workspace <workspace>.xcworkspace -scheme <scheme> | grep -E "(CODE_SIGN|PROVISIONING|DEVELOPMENT_TEAM)"
+
+# インストール済みプロビジョニングプロファイル一覧
+ls ~/Library/MobileDevice/Provisioning\ Profiles/
+
+# プロファイルの詳細確認
+security cms -D -i ~/Library/MobileDevice/Provisioning\ Profiles/<uuid>.mobileprovision
+
+# インストール済み証明書の確認
+security find-identity -v -p codesigning
+```
+
+## 検査項目
+
+### 1. 署名設定
+
+- `CODE_SIGN_IDENTITY` が設定されているか
+- `DEVELOPMENT_TEAM` が設定されているか
+- Automatic Signing（`CODE_SIGN_STYLE = Automatic`）の有無を確認
+- Manual Signing の場合、プロファイルが明示的に指定されているか
+
+### 2. プロビジョニングプロファイル
+
+- 指定されたプロファイルがローカルに存在するか（`~/Library/MobileDevice/Provisioning Profiles/`）
+- プロファイルの有効期限が切れていないか
+- プロファイルの App ID がプロジェクトの Bundle Identifier と一致するか
+- プロファイルの種類（Development / Ad Hoc / App Store）が配信目的と一致するか
+
+### 3. 証明書
+
+- `security find-identity` で有効な署名証明書が存在するか
+- 証明書の有効期限が切れていないか
+- プロファイルに紐づく証明書がキーチェーンに存在するか
+
+### 4. ビルド構成別チェック
+
+- Debug 構成: Development 証明書・プロファイルが設定されているか
+- Release 構成: Distribution 証明書・App Store プロファイルが設定されているか
+
+## 出力
+
+```
+## 署名・プロビジョニング確認結果
+
+### 署名設定
+- CODE_SIGN_IDENTITY: <値> (PASS / WARN)
+- DEVELOPMENT_TEAM: <値> (PASS / WARN)
+- CODE_SIGN_STYLE: Automatic / Manual (INFO)
+
+### プロビジョニングプロファイル
+- プロファイル: <名前> (PASS / WARN)
+- 有効期限: <日付> (PASS / WARN)
+- App ID: <値> (PASS / WARN)
+- 種類: Development / Ad Hoc / App Store (INFO)
+
+### 証明書
+- 署名証明書: <名前> (PASS / WARN)
+- 有効期限: <日付> (PASS / WARN)
+
+### 指摘事項
+- [WARN] <指摘内容>
+- [提案] <改善案>
+```
+
+## 検査対象の特定
+
+- 引数でプロジェクトパス・スキーム名が指定された場合はその設定を検査する
+- 指定がない場合はカレントディレクトリの `.xcodeproj` / `.xcworkspace` を自動検出する

--- a/plugins/ios-distribution/skills/testflight-upload/SKILL.md
+++ b/plugins/ios-distribution/skills/testflight-upload/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: testflight-upload
+description: アーカイブビルドと TestFlight アップロードを一括実行するワークフロー。archive-runner サブエージェントに処理を委譲する
+disable-model-invocation: true
+---
+
+# TestFlight アップロード
+
+> このスキルは `/testflight-upload` で明示的に実行します。自動活性化されません。
+
+アーカイブビルドから TestFlight へのアップロードまでを一括で実行するワークフロー。
+ビルド・アップロード処理は archive-runner サブエージェントに委譲する。
+
+## ツール使用方針
+
+- アーカイブは XcodeBuildMCP の利用を優先する
+- アップロードは `xcrun altool` CLI を使用する（MCP 非対応のため常に CLI）
+- ビルドログが膨大になるため、archive-runner サブエージェントに処理を委譲する
+
+### MCP 利用時（アーカイブ部分）
+
+- XcodeBuildMCP の `xcodebuild_archive` / `xcodebuild_export` ツールでアーカイブ + エクスポートする
+
+### CLI フォールバック（archive-runner が実行）
+
+```bash
+# アーカイブ + エクスポート（build-archive と同様）
+xcodebuild archive \
+  -workspace <workspace>.xcworkspace \
+  -scheme <scheme> \
+  -archivePath build/<scheme>.xcarchive \
+  -configuration Release \
+  -destination "generic/platform=iOS"
+
+xcodebuild -exportArchive \
+  -archivePath build/<scheme>.xcarchive \
+  -exportPath build/ipa \
+  -exportOptionsPlist ExportOptions.plist
+
+# TestFlight アップロード
+xcrun altool --upload-app \
+  --type ios \
+  --file build/ipa/<app-name>.ipa \
+  --apiKey <api-key> \
+  --apiIssuer <issuer-id>
+```
+
+## 実行フロー
+
+### Step 1: 事前確認
+
+signing-check スキルの内容に基づき、署名・プロビジョニングの設定を確認する。
+
+- プロジェクトファイルの存在確認
+- スキーム名の確認
+- ExportOptions.plist の存在確認
+- App Store Connect API キーの存在確認
+
+### Step 2: App Store Connect API キーの確認
+
+アップロードには API キーが必要。以下のいずれかで認証する。
+
+```bash
+# API キー認証（推奨）
+# ~/.appstoreconnect/private_keys/AuthKey_<KEY_ID>.p8 にキーを配置
+# --apiKey と --apiIssuer を指定
+
+# App 用パスワード認証（レガシー）
+# xcrun altool --upload-app --username <apple-id> --password <app-specific-password>
+```
+
+### Step 3: アーカイブ + アップロード実行
+
+archive-runner サブエージェントにアーカイブ・エクスポート・アップロードを一括で委譲する。
+
+### Step 4: 結果確認
+
+- アーカイブの成否を確認する
+- IPA エクスポートの成否を確認する
+- TestFlight アップロードの成否を確認する
+- エラーがあれば原因を分析して報告する
+
+## 出力
+
+```
+## TestFlight アップロード結果
+
+### 設定
+- プロジェクト: <プロジェクト名>
+- スキーム: <スキーム名>
+- 構成: Release
+
+### 実行結果
+1. アーカイブ: SUCCESS / FAILURE
+2. IPA エクスポート: SUCCESS / FAILURE
+3. TestFlight アップロード: SUCCESS / FAILURE
+
+### 詳細
+- IPA ファイル: <パス> (N MB)
+- アップロード先: App Store Connect
+- 処理時間: N 分
+
+### エラー（該当する場合）
+- <エラー内容>
+- [提案] <修正案>
+```
+
+## 引数
+
+- `--scheme <name>`: アーカイブ対象のスキーム名（省略時はプロジェクトから自動取得）
+- `--project <path>`: プロジェクトファイルのパス
+- `--workspace <path>`: ワークスペースファイルのパス
+- `--export-options <path>`: ExportOptions.plist のパス
+- `--api-key <key>`: App Store Connect API キー ID
+- `--api-issuer <issuer>`: App Store Connect Issuer ID


### PR DESCRIPTION
## Summary

- `ios-distribution` プラグインを新規実装（Tier 2: TestFlight 配信・署名）
- スキル 3 種: `signing-check`（署名・プロビジョニング確認）、`build-archive`（IPA 生成）、`testflight-upload`（archive + upload ワークフロー）
- サブエージェント 1 種: `archive-runner`（アーカイブ + アップロードの隔離実行）

## 設計方針

- `signing-check` は分析系のため `disable-model-invocation` 省略（自動発火）
- `build-archive` / `testflight-upload` は副作用を伴うため `disable-model-invocation: true`
- MCP 推奨 + CLI フォールバック: XcodeBuildMCP / xcodeproj-mcp-server を優先し、未導入時は xcodebuild / xcrun altool にフォールバック
- subagent（archive-runner）は MCP 非対応のため CLI のみ（Bash ツール）

## ファイル構成

```
plugins/ios-distribution/
├── .claude-plugin/
│   └── plugin.json
├── skills/
│   ├── signing-check/
│   │   └── SKILL.md
│   ├── build-archive/
│   │   └── SKILL.md
│   └── testflight-upload/
│       └── SKILL.md
└── agents/
    └── archive-runner.md
```

closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)