### PR TITLE
feat: feature-module-gen プラグインの実装

### DIFF
--- a/plugins/feature-module-gen/.claude-plugin/plugin.json
+++ b/plugins/feature-module-gen/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "feature-module-gen",
+  "version": "0.1.0",
+  "description": "SwiftUI + MVVM の Feature Module 雛形を一式生成し、SPM パッケージへの組み込みまで行う",
+  "skills": [
+    "skills/feature-scaffold",
+    "skills/view-gen",
+    "skills/viewmodel-gen",
+    "skills/repository-gen",
+    "skills/usecase-gen",
+    "skills/new-feature"
+  ],
+  "agents": [
+    "agents/module-generator.md"
+  ]
+}

--- a/plugins/feature-module-gen/agents/module-generator.md
+++ b/plugins/feature-module-gen/agents/module-generator.md
@@ -1,0 +1,241 @@
+---
+name: module-generator
+description: Feature Module のファイル一式を生成し、Package.swift を更新し、構文検証を行う
+tools: Bash, Read, Write, Glob, Grep
+model: sonnet
+---
+
+# モジュールジェネレーター
+
+Feature Module のファイル一式を生成し、SPM パッケージへの組み込みと構文検証まで行う。
+
+## スコープ
+
+### やること
+
+- 指定された Feature 名に基づきディレクトリ構造を作成する
+- View / ViewModel / Repository / UseCase / DI の各ファイルを生成する
+- 既存の Package.swift に target を追加する（SPM プロジェクトの場合）
+- 生成した全ファイルの Swift 構文検証を行う
+
+### やらないこと
+
+- 既存コードの修正は行わない
+- テストファイルの生成は行わない（別スキルの責務）
+- Xcode プロジェクトファイル（.xcodeproj）の操作は行わない
+
+## 実行手順
+
+### 1. ディレクトリ作成
+
+```bash
+mkdir -p Sources/<Feature名>Feature/Views
+mkdir -p Sources/<Feature名>Feature/ViewModels
+mkdir -p Sources/<Feature名>Feature/Repositories
+mkdir -p Sources/<Feature名>Feature/UseCases
+mkdir -p Sources/<Feature名>Feature/DI
+```
+
+### 2. ファイル生成
+
+以下のテンプレートに従い、各ファイルを Write ツールで生成する。
+
+#### View ファイル
+
+```swift
+import SwiftUI
+
+struct <Feature名>View: View {
+    @State private var viewModel: <Feature名>ViewModel
+
+    init(viewModel: <Feature名>ViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+            } else if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .foregroundStyle(.red)
+            } else {
+                Text("Hello, <Feature名>")
+            }
+        }
+        .task {
+            await viewModel.fetch()
+        }
+    }
+}
+
+#Preview {
+    <Feature名>View(
+        viewModel: <Feature名>ViewModel(
+            repository: <Feature名>RepositoryMock()
+        )
+    )
+}
+```
+
+#### ViewModel ファイル
+
+```swift
+import Foundation
+
+@Observable
+class <Feature名>ViewModel {
+    // MARK: - State
+
+    var isLoading: Bool = false
+    var errorMessage: String?
+
+    // MARK: - Dependencies
+
+    private let repository: <Feature名>RepositoryProtocol
+
+    // MARK: - Init
+
+    init(repository: <Feature名>RepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Actions
+
+    func fetch() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            // TODO: データ取得処理を実装
+            _ = try await repository.fetch()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+```
+
+#### Repository Protocol ファイル
+
+```swift
+import Foundation
+
+protocol <Feature名>RepositoryProtocol: Sendable {
+    func fetch() async throws -> <Feature名>Model
+    func save(_ model: <Feature名>Model) async throws
+}
+```
+
+#### Repository 具象実装ファイル
+
+```swift
+import Foundation
+
+final class <Feature名>Repository: <Feature名>RepositoryProtocol {
+    init() {}
+
+    func fetch() async throws -> <Feature名>Model {
+        // TODO: API 呼び出しを実装
+        fatalError("Not implemented")
+    }
+
+    func save(_ model: <Feature名>Model) async throws {
+        // TODO: API 呼び出しを実装
+        fatalError("Not implemented")
+    }
+}
+```
+
+#### UseCase ファイル
+
+```swift
+import Foundation
+
+protocol Fetch<Feature名>UseCaseProtocol: Sendable {
+    func execute() async throws -> <Feature名>Model
+}
+
+final class Fetch<Feature名>UseCase: Fetch<Feature名>UseCaseProtocol, Sendable {
+    private let repository: <Feature名>RepositoryProtocol
+
+    init(repository: <Feature名>RepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute() async throws -> <Feature名>Model {
+        return try await repository.fetch()
+    }
+}
+```
+
+#### DI ファイル
+
+```swift
+import SwiftUI
+
+struct <Feature名>Dependency {
+    let repository: <Feature名>RepositoryProtocol
+    let viewModel: <Feature名>ViewModel
+
+    static func resolve() -> <Feature名>Dependency {
+        let repository = <Feature名>Repository()
+        let viewModel = <Feature名>ViewModel(repository: repository)
+        return <Feature名>Dependency(repository: repository, viewModel: viewModel)
+    }
+}
+
+private struct <Feature名>DependencyKey: EnvironmentKey {
+    static let defaultValue: <Feature名>Dependency = .resolve()
+}
+
+extension EnvironmentValues {
+    var <feature名Camel>Dependency: <Feature名>Dependency {
+        get { self[<Feature名>DependencyKey.self] }
+        set { self[<Feature名>DependencyKey.self] = newValue }
+    }
+}
+```
+
+### 3. Package.swift 更新
+
+既存の Package.swift が存在する場合、`targets` 配列に以下を追加する。
+
+```swift
+.target(
+    name: "<Feature名>Feature",
+    dependencies: [],
+    path: "Sources/<Feature名>Feature"
+),
+```
+
+### 4. 構文検証
+
+生成した全 `.swift` ファイルに対し構文検証を行う。
+
+```bash
+# 個別ファイルの構文チェック
+swiftc -typecheck Sources/<Feature名>Feature/**/*.swift
+
+# SPM プロジェクトの場合
+swift build --target <Feature名>Feature 2>&1 | head -50
+```
+
+## 出力形式
+
+```
+## モジュール生成結果: <Feature名>Feature
+
+### 生成ファイル
+- Sources/<Feature名>Feature/Views/<Feature名>View.swift
+- Sources/<Feature名>Feature/ViewModels/<Feature名>ViewModel.swift
+- Sources/<Feature名>Feature/Repositories/<Feature名>RepositoryProtocol.swift
+- Sources/<Feature名>Feature/Repositories/<Feature名>Repository.swift
+- Sources/<Feature名>Feature/UseCases/Fetch<Feature名>UseCase.swift
+- Sources/<Feature名>Feature/DI/<Feature名>Dependency.swift
+
+### 構文検証
+- <ファイル名>: OK / NG（エラー内容）
+
+### Package.swift
+- 更新済み / スキップ（Package.swift が見つかりません）
+```

--- a/plugins/feature-module-gen/skills/feature-scaffold/SKILL.md
+++ b/plugins/feature-module-gen/skills/feature-scaffold/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: feature-scaffold
+description: Feature Module の雛形（View / ViewModel / Repository / DI）一式を生成する。「Feature Module」「雛形生成」「スキャフォールド」「scaffold」「新機能モジュール」で自動適用。
+---
+
+# Feature Module 雛形生成
+
+指定された Feature 名をもとに、SwiftUI + MVVM アーキテクチャに準拠した Feature Module の雛形ファイル一式を生成する。
+
+## ツール使用方針
+
+- ファイル作成・プロジェクトへの追加は xcodeproj-mcp-server の利用を優先する
+- 構文検証は XcodeBuildMCP の `swift_typecheck` を優先する
+- MCP が利用できない場合は `mkdir -p` / `cat` / `swift build` 等の CLI にフォールバックする
+
+## 入力
+
+- **Feature 名**（例: `UserProfile`）
+- **出力ディレクトリ**（省略時はプロジェクトルートの `Sources/` を推定）
+- **オプション**: UseCase の有無、Repository の有無
+
+## 生成ファイル一覧
+
+Feature 名が `UserProfile` の場合:
+
+```
+Sources/UserProfileFeature/
+├── Views/
+│   └── UserProfileView.swift
+├── ViewModels/
+│   └── UserProfileViewModel.swift
+├── Repositories/
+│   ├── UserProfileRepositoryProtocol.swift
+│   └── UserProfileRepository.swift
+├── UseCases/
+│   └── UserProfileUseCase.swift
+└── DI/
+    └── UserProfileDependency.swift
+```
+
+## 生成テンプレート
+
+各ファイルの生成時は以下のルールに従う。詳細なテンプレートは → **references/TEMPLATES.md** を参照。
+
+### View（SwiftUI）
+
+- `import SwiftUI` を使用する
+- ViewModel は `@State` で保持する（`@StateObject` は使わない）
+- DI は `@Environment` で注入する（`@EnvironmentObject` は使わない）
+- body はプレースホルダーの `Text` を配置する
+
+### ViewModel（@Observable）
+
+- `@Observable class` で宣言する（`ObservableObject` / `@Published` は使わない）
+- `import Foundation` のみ（`import SwiftUI` は禁止）
+- Repository は Protocol 経由でコンストラクタ注入する
+- エラーハンドリング用の `var errorMessage: String?` を含める
+- ローディング状態用の `var isLoading: Bool` を含める
+
+### Repository + Protocol
+
+- Protocol と具象クラスを別ファイルに分離する
+- メソッドは `async throws` で定義する
+- `Sendable` に準拠する
+
+### UseCase
+
+- 単一責務の `execute` メソッドを持つ
+- Repository を Protocol 経由で注入する
+- `Sendable` に準拠する
+
+### DI（Dependency Container）
+
+- Protocol ベースの依存解決を提供する
+- `@Environment` での注入に対応する
+
+## 生成後の確認
+
+1. 生成したファイルが Swift の構文として正しいか検証する
+   - MCP: XcodeBuildMCP の `swift_typecheck` を使用
+   - CLI フォールバック: `swiftc -typecheck <ファイル>` を実行
+2. 既存の Package.swift があれば target の追加を提案する

--- a/plugins/feature-module-gen/skills/feature-scaffold/references/TEMPLATES.md
+++ b/plugins/feature-module-gen/skills/feature-scaffold/references/TEMPLATES.md
@@ -1,0 +1,315 @@
+# Feature Module テンプレート詳細（Swift 6.2 / SwiftUI）
+
+## View テンプレート
+
+### 標準パターン
+
+```swift
+import SwiftUI
+
+struct <Feature名>View: View {
+    @State private var viewModel: <Feature名>ViewModel
+
+    init(viewModel: <Feature名>ViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+            } else if let errorMessage = viewModel.errorMessage {
+                ContentUnavailableView(
+                    "Error",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(errorMessage)
+                )
+            } else {
+                contentView
+            }
+        }
+        .task {
+            await viewModel.fetch()
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        Text("Hello, <Feature名>")
+    }
+}
+
+#Preview {
+    <Feature名>View(
+        viewModel: <Feature名>ViewModel(
+            repository: <Feature名>RepositoryMock()
+        )
+    )
+}
+```
+
+### ナビゲーション付きパターン
+
+```swift
+import SwiftUI
+
+struct <Feature名>View: View {
+    @State private var viewModel: <Feature名>ViewModel
+
+    init(viewModel: <Feature名>ViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationStack {
+            contentView
+                .navigationTitle("<Feature名>")
+                .task {
+                    await viewModel.fetch()
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        // TODO: コンテンツを実装
+        Text("Hello, <Feature名>")
+    }
+}
+```
+
+### リスト表示パターン
+
+```swift
+import SwiftUI
+
+struct <Feature名>ListView: View {
+    @State private var viewModel: <Feature名>ListViewModel
+
+    init(viewModel: <Feature名>ListViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        List(viewModel.items) { item in
+            <Feature名>RowView(item: item)
+        }
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView()
+            }
+        }
+        .refreshable {
+            await viewModel.refresh()
+        }
+        .task {
+            await viewModel.fetch()
+        }
+    }
+}
+```
+
+## ViewModel テンプレート
+
+### 標準パターン
+
+```swift
+import Foundation
+
+@Observable
+class <Feature名>ViewModel {
+    // MARK: - State
+
+    var isLoading: Bool = false
+    var errorMessage: String?
+
+    // MARK: - Dependencies
+
+    private let repository: <Feature名>RepositoryProtocol
+
+    // MARK: - Init
+
+    init(repository: <Feature名>RepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Actions
+
+    func fetch() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            // TODO: データ取得処理を実装
+            _ = try await repository.fetch()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+```
+
+### UseCase 経由パターン
+
+```swift
+import Foundation
+
+@Observable
+class <Feature名>ViewModel {
+    // MARK: - State
+
+    var isLoading: Bool = false
+    var errorMessage: String?
+
+    // MARK: - Dependencies
+
+    private let fetchUseCase: Fetch<Feature名>UseCaseProtocol
+
+    // MARK: - Init
+
+    init(fetchUseCase: Fetch<Feature名>UseCaseProtocol) {
+        self.fetchUseCase = fetchUseCase
+    }
+
+    // MARK: - Actions
+
+    func fetch() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            _ = try await fetchUseCase.execute()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+```
+
+## Repository テンプレート
+
+### Protocol
+
+```swift
+import Foundation
+
+protocol <Feature名>RepositoryProtocol: Sendable {
+    func fetch() async throws -> <Feature名>Model
+    func save(_ model: <Feature名>Model) async throws
+    func delete(id: String) async throws
+}
+```
+
+### 具象実装（URLSession ベース）
+
+```swift
+import Foundation
+
+final class <Feature名>Repository: <Feature名>RepositoryProtocol {
+    private let session: URLSession
+    private let baseURL: URL
+
+    init(
+        session: URLSession = .shared,
+        baseURL: URL
+    ) {
+        self.session = session
+        self.baseURL = baseURL
+    }
+
+    func fetch() async throws -> <Feature名>Model {
+        let url = baseURL.appendingPathComponent("<endpoint>")
+        let (data, _) = try await session.data(from: url)
+        return try JSONDecoder().decode(<Feature名>Model.self, from: data)
+    }
+
+    func save(_ model: <Feature名>Model) async throws {
+        // TODO: POST/PUT リクエスト
+    }
+
+    func delete(id: String) async throws {
+        // TODO: DELETE リクエスト
+    }
+}
+```
+
+### モック（テスト・プレビュー用）
+
+```swift
+import Foundation
+
+final class <Feature名>RepositoryMock: <Feature名>RepositoryProtocol {
+    var fetchResult: Result<<Feature名>Model, Error> = .success(.mock)
+
+    func fetch() async throws -> <Feature名>Model {
+        return try fetchResult.get()
+    }
+
+    func save(_ model: <Feature名>Model) async throws {}
+
+    func delete(id: String) async throws {}
+}
+```
+
+## UseCase テンプレート
+
+```swift
+import Foundation
+
+protocol Fetch<Feature名>UseCaseProtocol: Sendable {
+    func execute() async throws -> <Feature名>Model
+}
+
+final class Fetch<Feature名>UseCase: Fetch<Feature名>UseCaseProtocol, Sendable {
+    private let repository: <Feature名>RepositoryProtocol
+
+    init(repository: <Feature名>RepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute() async throws -> <Feature名>Model {
+        return try await repository.fetch()
+    }
+}
+```
+
+## DI テンプレート
+
+### Environment ベースの依存注入
+
+```swift
+import SwiftUI
+
+struct <Feature名>Dependency {
+    let repository: <Feature名>RepositoryProtocol
+    let viewModel: <Feature名>ViewModel
+
+    static func resolve() -> <Feature名>Dependency {
+        let repository = <Feature名>Repository()
+        let viewModel = <Feature名>ViewModel(repository: repository)
+        return <Feature名>Dependency(repository: repository, viewModel: viewModel)
+    }
+}
+
+private struct <Feature名>DependencyKey: EnvironmentKey {
+    static let defaultValue: <Feature名>Dependency = .resolve()
+}
+
+extension EnvironmentValues {
+    var <feature名Camel>Dependency: <Feature名>Dependency {
+        get { self[<Feature名>DependencyKey.self] }
+        set { self[<Feature名>DependencyKey.self] = newValue }
+    }
+}
+```
+
+## 新旧パターン対照表（レガシー → 推奨の移行ガイド）
+
+以下は非推奨（旧）パターンと推奨（新）パターンの対照表。旧パターンは使わない。
+
+| 旧（非推奨） | 新（推奨） | 理由 |
+|---|---|---|
+| `class VM: ObservableObject` | `@Observable class VM` | Observation フレームワーク |
+| `@Published var` | `var` | `@Observable` では不要 |
+| `@StateObject private var vm` | `@State private var vm` | 新しいオーナーシップ API |
+| `@ObservedObject var vm`（旧・非推奨） | `var vm` or `@Bindable var vm` | バインディング要否で選択 |
+| `@EnvironmentObject var`（旧・非推奨） | `@Environment(Type.self) var` | 型安全な環境注入 |
+| `PreviewProvider`（旧・非推奨） | `#Preview` | マクロベースのプレビュー |

--- a/plugins/feature-module-gen/skills/new-feature/SKILL.md
+++ b/plugins/feature-module-gen/skills/new-feature/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: new-feature
+description: 対話的に Feature Module 一式を生成するワークフロー。feature-scaffold・view-gen・viewmodel-gen・repository-gen・usecase-gen と module-generator サブエージェントを組み合わせて実行する
+disable-model-invocation: true
+---
+
+# Feature Module 一式生成ワークフロー
+
+> このスキルは `/new-feature` で明示的に実行します。自動活性化されません。
+
+対話的に Feature Module の構成を決定し、一式を生成するワークフロー。
+個別スキル（feature-scaffold, view-gen, viewmodel-gen, repository-gen, usecase-gen）と
+module-generator サブエージェントを組み合わせて実行する。
+
+## ツール使用方針
+
+- ファイル生成は xcodeproj-mcp-server の利用を優先する
+- 構文検証は XcodeBuildMCP の `swift_typecheck` を優先する
+- MCP が利用できない場合は `mkdir -p` / `cat` / `swiftc -typecheck` 等の CLI にフォールバックする
+- module-generator サブエージェントは CLI のみで動作する
+
+## 実行フロー
+
+### Step 1: ヒアリング
+
+ユーザーに以下の情報を確認する。
+
+| 項目 | 必須 | デフォルト |
+|---|---|---|
+| Feature 名（例: `UserProfile`） | 必須 | - |
+| 出力ディレクトリ | 任意 | `Sources/<Feature名>Feature/` |
+| UseCase の有無 | 任意 | あり |
+| Repository の有無 | 任意 | あり |
+| 追加の画面（子 View）の有無 | 任意 | なし |
+| SPM Package.swift への追加 | 任意 | あり（既存の Package.swift がある場合） |
+
+### Step 2: ファイル生成（subagent）
+
+module-generator サブエージェントを起動し、以下を実行する。
+
+1. ディレクトリ構造の作成
+2. 各ファイルの生成（feature-scaffold に準拠したテンプレート）
+3. Package.swift への target 追加（SPM プロジェクトの場合）
+4. 生成ファイルの構文検証
+
+### Step 3: 個別スキルによる検証
+
+生成されたファイルに対し、以下のスキルで品質を確認する。
+
+1. **view-gen** の規約に準拠しているか
+2. **viewmodel-gen** の規約に準拠しているか
+3. **repository-gen** の規約に準拠しているか
+4. **usecase-gen** の規約に準拠しているか
+
+### Step 4: 結果レポート
+
+生成結果を報告し、次のアクションを提案する。
+
+## 出力
+
+```
+## Feature Module 生成結果: <Feature名>Feature
+
+### 生成ファイル一覧
+- Views/<Feature名>View.swift
+- ViewModels/<Feature名>ViewModel.swift
+- Repositories/<Feature名>RepositoryProtocol.swift
+- Repositories/<Feature名>Repository.swift
+- UseCases/<Feature名>UseCase.swift
+- DI/<Feature名>Dependency.swift
+
+### 構文検証: PASS / FAIL
+- <ファイル名>: OK / NG（エラー内容）
+
+### Package.swift: 更新済み / スキップ
+
+### 次のアクション
+- [ ] 生成された TODO コメントを実装に置き換える
+- [ ] ユニットテストを作成する（/unit-test-gen を推奨）
+- [ ] MVVM 準拠を確認する（/mvvm-check を推奨）
+```

--- a/plugins/feature-module-gen/skills/repository-gen/SKILL.md
+++ b/plugins/feature-module-gen/skills/repository-gen/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: repository-gen
+description: Repository と Protocol ファイルを生成する。データアクセス層の抽象化と具象実装を分離。「Repository 生成」「データアクセス」「API クライアント」「Repository 作成」で自動適用。
+---
+
+# Repository + Protocol 生成
+
+指定されたドメインに基づき、Repository の Protocol 定義と具象実装を生成する。
+
+## ツール使用方針
+
+- ファイル作成・プロジェクトへの追加は xcodeproj-mcp-server の利用を優先する
+- 構文検証は XcodeBuildMCP の `swift_typecheck` を優先する
+- MCP が利用できない場合は `cat` / `swiftc -typecheck` 等の CLI にフォールバックする
+
+## 入力
+
+- **Repository 名**（例: `UserProfileRepository`）
+- **ドメインの説明**（省略可。指定された場合はメソッドを調整する）
+- **出力先ディレクトリ**（省略時は `Repositories/` を推定）
+
+## 生成ファイル
+
+1 つの Repository に対し、Protocol ファイルと具象実装ファイルの 2 ファイルを生成する。
+
+### Protocol ファイル
+
+```swift
+import Foundation
+
+protocol <RepositoryName>Protocol: Sendable {
+    func fetch() async throws -> <ModelName>
+    func save(_ model: <ModelName>) async throws
+}
+```
+
+### 具象実装ファイル
+
+```swift
+import Foundation
+
+final class <RepositoryName>: <RepositoryName>Protocol {
+    // MARK: - Dependencies
+
+    private let apiClient: APIClientProtocol
+
+    // MARK: - Init
+
+    init(apiClient: APIClientProtocol) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - <RepositoryName>Protocol
+
+    func fetch() async throws -> <ModelName> {
+        // TODO: API 呼び出し
+        fatalError("Not implemented")
+    }
+
+    func save(_ model: <ModelName>) async throws {
+        // TODO: API 呼び出し
+        fatalError("Not implemented")
+    }
+}
+```
+
+### 規約
+
+- Protocol と具象クラスは別ファイルに分離する
+- Protocol は `Sendable` に準拠する
+- メソッドは `async throws` で定義する
+- 具象クラスは `final class` で宣言する
+- 依存（API クライアント等）は Protocol 経由でコンストラクタ注入する
+- `import Foundation` のみ（`import SwiftUI` は禁止）
+
+## 生成後の確認
+
+- 生成したファイルが Swift の構文として正しいか検証する
+  - MCP: XcodeBuildMCP の `swift_typecheck` を使用
+  - CLI フォールバック: `swiftc -typecheck <ファイル>` を実行

--- a/plugins/feature-module-gen/skills/usecase-gen/SKILL.md
+++ b/plugins/feature-module-gen/skills/usecase-gen/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: usecase-gen
+description: UseCase ファイルを生成する。単一責務の execute メソッドを持つ UseCase パターン。「UseCase 生成」「ユースケース」「ビジネスロジック」「UseCase 作成」で自動適用。
+---
+
+# UseCase 生成
+
+指定されたユースケースに基づき、単一責務の UseCase ファイルを生成する。
+
+## ツール使用方針
+
+- ファイル作成・プロジェクトへの追加は xcodeproj-mcp-server の利用を優先する
+- 構文検証は XcodeBuildMCP の `swift_typecheck` を優先する
+- MCP が利用できない場合は `cat` / `swiftc -typecheck` 等の CLI にフォールバックする
+
+## 入力
+
+- **UseCase 名**（例: `FetchUserProfileUseCase`）
+- **責務の説明**（省略可。指定された場合は execute メソッドのシグネチャを調整する）
+- **出力先ディレクトリ**（省略時は `UseCases/` を推定）
+
+## 生成テンプレート
+
+### Protocol + 具象実装
+
+```swift
+import Foundation
+
+protocol <UseCaseName>Protocol: Sendable {
+    func execute() async throws -> <ReturnType>
+}
+
+final class <UseCaseName>: <UseCaseName>Protocol, Sendable {
+    // MARK: - Dependencies
+
+    private let repository: <RepositoryProtocolName>
+
+    // MARK: - Init
+
+    init(repository: <RepositoryProtocolName>) {
+        self.repository = repository
+    }
+
+    // MARK: - Execute
+
+    func execute() async throws -> <ReturnType> {
+        // TODO: ビジネスロジック
+        return try await repository.fetch()
+    }
+}
+```
+
+### 規約
+
+- 1 UseCase = 1 責務（Single Responsibility）
+- 公開メソッドは `execute` のみとする
+- `Sendable` に準拠する
+- Protocol を定義しテスタビリティを確保する
+- Repository は Protocol 経由でコンストラクタ注入する
+- `import Foundation` のみ（`import SwiftUI` は禁止）
+- `async throws` で非同期エラーハンドリングに対応する
+- 複数の Repository を組み合わせるオーケストレーションも UseCase の責務とする
+
+### 複数 Repository を使う場合
+
+```swift
+final class PlaceOrderUseCase: PlaceOrderUseCaseProtocol, Sendable {
+    private let orderRepository: OrderRepositoryProtocol
+    private let paymentRepository: PaymentRepositoryProtocol
+
+    init(
+        orderRepository: OrderRepositoryProtocol,
+        paymentRepository: PaymentRepositoryProtocol
+    ) {
+        self.orderRepository = orderRepository
+        self.paymentRepository = paymentRepository
+    }
+
+    func execute(order: Order) async throws -> OrderConfirmation {
+        let payment = try await paymentRepository.process(order.payment)
+        return try await orderRepository.place(order, payment: payment)
+    }
+}
+```
+
+## 生成後の確認
+
+- 生成したファイルが Swift の構文として正しいか検証する
+  - MCP: XcodeBuildMCP の `swift_typecheck` を使用
+  - CLI フォールバック: `swiftc -typecheck <ファイル>` を実行

--- a/plugins/feature-module-gen/skills/view-gen/SKILL.md
+++ b/plugins/feature-module-gen/skills/view-gen/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: view-gen
+description: SwiftUI View ファイルを生成する。チーム規約に準拠した View テンプレートを出力。「View 生成」「SwiftUI View」「画面作成」「UI 生成」で自動適用。
+---
+
+# SwiftUI View 生成
+
+指定された画面名・用途に基づき、チーム規約に準拠した SwiftUI View ファイルを生成する。
+
+## ツール使用方針
+
+- ファイル作成・プロジェクトへの追加は xcodeproj-mcp-server の利用を優先する
+- 構文検証は XcodeBuildMCP の `swift_typecheck` を優先する
+- MCP が利用できない場合は `cat` / `swiftc -typecheck` 等の CLI にフォールバックする
+
+## 入力
+
+- **View 名**（例: `UserProfileView`）
+- **用途の説明**（省略可。指定された場合は body の内容を調整する）
+- **出力先ディレクトリ**（省略時は `Views/` を推定）
+
+## 生成ルール
+
+### 基本構造
+
+```swift
+import SwiftUI
+
+struct <ViewName>: View {
+    @State private var viewModel: <ViewModelName>
+
+    init(viewModel: <ViewModelName>) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        Text("Hello, <ViewName>")
+    }
+}
+
+#Preview {
+    <ViewName>(viewModel: <ViewModelName>())
+}
+```
+
+### 規約
+
+- ViewModel は `@State` で保持する（`@StateObject` は使わない）
+- `@EnvironmentObject` は使わず `@Environment` で環境値を注入する
+- body 内にビジネスロジックを記述しない（ViewModel に委譲する）
+- `#Preview` マクロでプレビューを定義する（旧 `PreviewProvider` は使わない）
+- View が Repository / Service に直接依存しない
+
+### バインディングが必要な場合
+
+子 View で ViewModel のプロパティに書き込む場合は `@Bindable` を使用する。
+
+```swift
+struct <ChildViewName>: View {
+    @Bindable var viewModel: <ViewModelName>
+
+    var body: some View {
+        TextField("Name", text: $viewModel.name)
+    }
+}
+```
+
+詳細なパターン例は → **references/VIEW_PATTERNS.md** を参照。
+
+## 生成後の確認
+
+- 生成したファイルが Swift の構文として正しいか検証する
+  - MCP: XcodeBuildMCP の `swift_typecheck` を使用
+  - CLI フォールバック: `swiftc -typecheck <ファイル>` を実行

--- a/plugins/feature-module-gen/skills/view-gen/references/VIEW_PATTERNS.md
+++ b/plugins/feature-module-gen/skills/view-gen/references/VIEW_PATTERNS.md
@@ -1,0 +1,154 @@
+# SwiftUI View パターン集（Swift 6.2）
+
+## 基本パターン
+
+### ViewModel 注入パターン
+
+```swift
+import SwiftUI
+
+struct UserProfileView: View {
+    @State private var viewModel: UserProfileViewModel
+
+    init(viewModel: UserProfileViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        Text(viewModel.displayName)
+    }
+}
+```
+
+### Environment 注入パターン
+
+```swift
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(AppSettings.self) private var settings
+
+    var body: some View {
+        Toggle("Dark Mode", isOn: settings.isDarkMode)
+    }
+}
+```
+
+### @Bindable パターン（子 View で双方向バインディング）
+
+```swift
+import SwiftUI
+
+struct UserEditView: View {
+    @Bindable var viewModel: UserProfileViewModel
+
+    var body: some View {
+        Form {
+            TextField("Name", text: $viewModel.name)
+            TextField("Email", text: $viewModel.email)
+        }
+    }
+}
+```
+
+## ローディング・エラーハンドリング
+
+### 標準パターン
+
+```swift
+struct ContentLoadingView: View {
+    @State private var viewModel: ContentViewModel
+
+    init(viewModel: ContentViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+            } else if let errorMessage = viewModel.errorMessage {
+                ContentUnavailableView(
+                    "Error",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(errorMessage)
+                )
+            } else {
+                contentView
+            }
+        }
+        .task {
+            await viewModel.fetch()
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        // メインコンテンツ
+    }
+}
+```
+
+## ナビゲーションパターン
+
+### NavigationStack + NavigationLink
+
+```swift
+struct ItemListView: View {
+    @State private var viewModel: ItemListViewModel
+
+    init(viewModel: ItemListViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List(viewModel.items) { item in
+                NavigationLink(value: item) {
+                    ItemRowView(item: item)
+                }
+            }
+            .navigationTitle("Items")
+            .navigationDestination(for: Item.self) { item in
+                ItemDetailView(
+                    viewModel: ItemDetailViewModel(item: item)
+                )
+            }
+        }
+    }
+}
+```
+
+## レガシーパターンとの対照
+
+| 旧（使わない） | 新（使う） |
+|---|---|
+| `@StateObject private var vm = VM()` | `@State private var vm: VM` + init |
+| `@ObservedObject var vm: VM` | `var vm: VM` or `@Bindable var vm: VM` |
+| `@EnvironmentObject var settings: Settings` | `@Environment(Settings.self) private var settings` |
+| `struct Preview: PreviewProvider { ... }` | `#Preview { ... }` |
+
+## UI 状態の @State（ViewModel ではなく View ローカル状態）
+
+```swift
+struct ExampleView: View {
+    @State private var viewModel: ExampleViewModel
+    // UI 一時状態は @State でそのまま保持して良い
+    @State private var isSheetPresented = false
+    @State private var searchText = ""
+
+    init(viewModel: ExampleViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        List(viewModel.filteredItems(searchText: searchText)) { item in
+            Text(item.name)
+        }
+        .searchable(text: $searchText)
+        .sheet(isPresented: $isSheetPresented) {
+            DetailSheet()
+        }
+    }
+}
+```

--- a/plugins/feature-module-gen/skills/viewmodel-gen/SKILL.md
+++ b/plugins/feature-module-gen/skills/viewmodel-gen/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: viewmodel-gen
+description: ViewModel ファイルを生成する。@Observable ベースで Input/Output パターンに対応。「ViewModel 生成」「@Observable」「ViewModel 作成」で自動適用。
+---
+
+# ViewModel 生成
+
+指定された ViewModel 名・責務に基づき、`@Observable` ベースの ViewModel ファイルを生成する。
+
+## ツール使用方針
+
+- ファイル作成・プロジェクトへの追加は xcodeproj-mcp-server の利用を優先する
+- 構文検証は XcodeBuildMCP の `swift_typecheck` を優先する
+- MCP が利用できない場合は `cat` / `swiftc -typecheck` 等の CLI にフォールバックする
+
+## 入力
+
+- **ViewModel 名**（例: `UserProfileViewModel`）
+- **責務の説明**（省略可。指定された場合はプロパティ・メソッドを調整する）
+- **出力先ディレクトリ**（省略時は `ViewModels/` を推定）
+
+## 生成ルール
+
+### 基本テンプレート
+
+```swift
+import Foundation
+
+@Observable
+class <ViewModelName> {
+    // MARK: - State
+
+    var isLoading: Bool = false
+    var errorMessage: String?
+
+    // MARK: - Dependencies
+
+    private let repository: <RepositoryProtocolName>
+
+    // MARK: - Init
+
+    init(repository: <RepositoryProtocolName>) {
+        self.repository = repository
+    }
+
+    // MARK: - Actions
+
+    func fetch() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            // TODO: データ取得処理
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+```
+
+### 規約
+
+- `@Observable class` で宣言する（`ObservableObject` / `@Published` は使わない）
+- `import Foundation` のみ（`import SwiftUI` は禁止）
+- 依存は Protocol 経由でコンストラクタ注入する
+- `isLoading` と `errorMessage` を標準のステートプロパティとして含める
+- 非同期メソッドは `async` / `async throws` で定義する
+- 他の ViewModel を直接参照しない（Protocol 経由で必要なデータのみ注入する）
+- UI 更新が必要なプロパティは `@MainActor` で保護する
+
+### Input / Output パターン（オプション）
+
+責務が複雑な ViewModel では Input / Output の分離を適用できる。
+
+```swift
+@Observable
+class <ViewModelName> {
+    // MARK: - Output (State)
+
+    var items: [Item] = []
+    var isLoading: Bool = false
+    var errorMessage: String?
+
+    // MARK: - Input (Actions)
+
+    func onAppear() async { ... }
+    func onRefresh() async { ... }
+    func onItemTapped(_ item: Item) { ... }
+}
+```
+
+詳細なパターン例は → **references/VIEWMODEL_PATTERNS.md** を参照。
+
+## 生成後の確認
+
+- 生成したファイルが Swift の構文として正しいか検証する
+  - MCP: XcodeBuildMCP の `swift_typecheck` を使用
+  - CLI フォールバック: `swiftc -typecheck <ファイル>` を実行

--- a/plugins/feature-module-gen/skills/viewmodel-gen/references/VIEWMODEL_PATTERNS.md
+++ b/plugins/feature-module-gen/skills/viewmodel-gen/references/VIEWMODEL_PATTERNS.md
@@ -1,0 +1,186 @@
+# ViewModel パターン集（Swift 6.2 / @Observable）
+
+## 基本パターン
+
+### 最小構成
+
+```swift
+import Foundation
+
+@Observable
+class SimpleViewModel {
+    var isLoading: Bool = false
+    var errorMessage: String?
+
+    private let repository: SimpleRepositoryProtocol
+
+    init(repository: SimpleRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func fetch() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            // データ取得
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+```
+
+## Input / Output パターン
+
+責務が複雑な ViewModel で、ユーザーアクション（Input）と画面状態（Output）を明確に分離する。
+
+```swift
+import Foundation
+
+@Observable
+class UserListViewModel {
+    // MARK: - Output (State)
+
+    var users: [User] = []
+    var isLoading: Bool = false
+    var errorMessage: String?
+    var hasMorePages: Bool = true
+
+    // MARK: - Private State
+
+    private var currentPage: Int = 0
+
+    // MARK: - Dependencies
+
+    private let repository: UserRepositoryProtocol
+
+    // MARK: - Init
+
+    init(repository: UserRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    // MARK: - Input (Actions)
+
+    func onAppear() async {
+        await fetchInitialPage()
+    }
+
+    func onRefresh() async {
+        currentPage = 0
+        users = []
+        await fetchInitialPage()
+    }
+
+    func onLoadMore() async {
+        guard !isLoading, hasMorePages else { return }
+        currentPage += 1
+        await fetchPage(currentPage)
+    }
+
+    func onUserTapped(_ user: User) {
+        // ナビゲーション処理
+    }
+
+    // MARK: - Private
+
+    private func fetchInitialPage() async {
+        await fetchPage(0)
+    }
+
+    private func fetchPage(_ page: Int) async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let result = try await repository.fetchUsers(page: page)
+            users.append(contentsOf: result.users)
+            hasMorePages = result.hasMore
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+```
+
+## UseCase 経由パターン
+
+ViewModel が Repository に直接依存せず、UseCase を介してビジネスロジックを呼び出す。
+
+```swift
+import Foundation
+
+@Observable
+class OrderViewModel {
+    var order: Order?
+    var isLoading: Bool = false
+    var errorMessage: String?
+
+    private let fetchOrderUseCase: FetchOrderUseCaseProtocol
+    private let cancelOrderUseCase: CancelOrderUseCaseProtocol
+
+    init(
+        fetchOrderUseCase: FetchOrderUseCaseProtocol,
+        cancelOrderUseCase: CancelOrderUseCaseProtocol
+    ) {
+        self.fetchOrderUseCase = fetchOrderUseCase
+        self.cancelOrderUseCase = cancelOrderUseCase
+    }
+
+    func fetch(orderId: String) async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            order = try await fetchOrderUseCase.execute(id: orderId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func cancel() async {
+        guard let order else { return }
+        do {
+            try await cancelOrderUseCase.execute(id: order.id)
+            self.order = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+```
+
+## @MainActor パターン
+
+UI 更新が頻繁に発生する ViewModel では `@MainActor` でクラス全体を保護する。
+
+```swift
+import Foundation
+
+@MainActor
+@Observable
+class RealTimeViewModel {
+    var messages: [Message] = []
+    var connectionStatus: ConnectionStatus = .disconnected
+
+    private let repository: ChatRepositoryProtocol
+
+    init(repository: ChatRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func startListening() async {
+        connectionStatus = .connected
+        for await message in repository.messageStream() {
+            messages.append(message)
+        }
+    }
+}
+```
+
+## レガシーからの移行
+
+| 旧（非推奨） | 新（推奨） |
+|---|---|
+| `class VM: ObservableObject` | `@Observable class VM` |
+| `@Published var name = ""` | `var name = ""` |
+| `objectWillChange.send()` | 不要（自動追跡） |
+| `$viewModel.name` (from @Published) | `$viewModel.name` (from @Bindable) |


### PR DESCRIPTION
## Summary

- SwiftUI + MVVM の Feature Module 雛形を一式生成する `feature-module-gen` プラグインを実装
- Swift 6.2 / `@Observable` ベースのテンプレートを提供（`ObservableObject` / `@Published` は非推奨として扱い使用しない）
- SPM パッケージへの組み込み（Package.swift 更新）までをサポート

### スキル構成

| 種別 | 名前 | 内容 |
|---|---|---|
| skill | feature-scaffold | Feature Module 雛形（View / ViewModel / Repository / DI）一式生成 |
| skill | view-gen | SwiftUI View 生成（チーム規約準拠） |
| skill | viewmodel-gen | ViewModel 生成（@Observable ベース） |
| skill | repository-gen | Repository + Protocol 生成 |
| skill | usecase-gen | UseCase 生成 |
| subagent | module-generator | モジュール一式生成 + Package.swift 更新 + 構文検証 |
| skill (manual) | new-feature | 対話的に Feature Module 一式生成ワークフロー |

## Test plan

- [x] plugin.json の必須フィールド（name, version, description）が存在する
- [x] 全スキルの SKILL.md が存在し、frontmatter に name, description が含まれる
- [x] subagent の agent.md が存在し、frontmatter に name, description, tools, model が含まれる
- [x] plugin.json のパスと実ファイルが一致する
- [x] 命名規則（kebab-case、64文字以内）に準拠している
- [x] MCP 推奨 + CLI フォールバックが全スキルに記述されている
- [x] subagent は CLI のみで実装されている（MCP ツール不使用）
- [x] disable-model-invocation: new-feature → true、それ以外 → false（省略）
- [x] Swift 6.2 準拠（@Observable のみ、レガシーパターンは NG 文脈でのみ言及）
- [x] 本文が日本語で記述されている（コード例は英語）
- [x] description にトリガーキーワードが含まれている

closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)