### PR TITLE
refactor: プラグイン情報を各ディレクトリの README.md に分離

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,185 +14,26 @@ iOS チーム開発を包括的にサポートする Claude Code プラグイン
 
 ## プラグイン一覧
 
-### スキルの種別
-
-| 表記 | 意味 | `disable-model-invocation` |
-|---|---|---|
-| skill | Claude が文脈に応じて自動で発火する | `false`（デフォルト） |
-| skill (manual) | ユーザーが `/skill-name` で明示的に実行する。ワークフローや副作用を伴う操作 | `true` |
-
 ### Tier 1: 日常の開発サイクルで毎日使うもの
 
-#### 1. `ios-architecture` — アーキテクチャガード
-
-MVVM パターンの構造チェック・レイヤー間の依存方向検査・DI パターンの提案を行う。
-
-| 種別 | 名前 | 内容 |
+| # | プラグイン | 概要 |
 |---|---|---|
-| skill | mvvm-check | View / ViewModel / Model 分離の検査 |
-| skill | layer-dependency-check | レイヤー間の依存方向チェック |
-| skill | di-pattern-suggest | Dependency Injection パターンの提案 |
-| skill | protocol-oriented-check | Protocol 指向設計の推奨・改善提案 |
-| skill | concurrency-check | Swift Concurrency の安全性検査（Swift 6.2+） |
-| subagent | architecture-scanner | 全モジュールの依存関係分析 |
-| skill (manual) | arch-audit | アーキテクチャ全体監査ワークフロー |
-
-#### 2. `team-conventions` — 規約エンフォーサー
-
-チームのコーディング規約・命名規則・ブランチ運用ルールを自動で検査・強制する。
-hooks でコード生成前に規約を注入し、最初から規約通りに書く。
-
-| 種別 | 名前 | 内容 |
-|---|---|---|
-| skill | naming-check | Swift 命名規則（API Design Guidelines 準拠）チェック |
-| skill | file-structure-check | ファイル配置がチーム規約に沿っているか検査 |
-| skill | commit-message-lint | コミットメッセージ形式チェック |
-| skill | branch-naming-check | ブランチ命名規則の検証 |
-| skill | pr-description-gen | PR テンプレートに基づく説明文の自動生成 |
-| subagent | convention-scanner | プロジェクト全体の規約準拠スキャン |
-| skill (manual) | convention-check | 変更ファイルに対する規約チェック一括ワークフロー |
-| hooks | UserPromptSubmit | コード生成時に規約をコンテキスト注入 |
-
-#### 3. `swift-code-quality` — コード品質ガード
-
-SwiftLint / SwiftFormat による静的解析と軽量な構文チェックで、フルビルドなしにコード品質を担保する。
-
-| 種別 | 名前 | 内容 |
-|---|---|---|
-| skill | swift-lint | SwiftLint 実行 + 違反の自動修正 |
-| skill | swift-format | SwiftFormat 実行 |
-| skill | syntax-typecheck | `swiftc -typecheck` による軽量構文チェック |
-| skill | complexity-analysis | 循環的複雑度・関数行数の分析 |
-| skill | dead-code-detect | 未使用コード・未使用 import の検出 |
-| skill | type-safety-check | force unwrap / force cast の検出 + 安全な書き換え提案 |
-| subagent | lint-scanner | プロジェクト全体の lint 一括スキャン |
-| skill (manual) | quality-check | lint + format + typecheck 一括ワークフロー |
-
-#### 4. `swift-testing` — テスト生成・実行
-
-ユニットテスト・UI テストの生成からテスト実行・カバレッジ分析まで、テストのライフサイクル全体をサポートする。
-
-| 種別 | 名前 | 内容 |
-|---|---|---|
-| skill | unit-test-gen | 対象コードからユニットテスト生成 |
-| skill | ui-test-gen | SwiftUI 画面から XCUITest 生成 |
-| skill | mock-gen | Protocol 準拠のモック / スタブ自動生成 |
-| skill | test-pattern-suggest | テスト対象に適切なテストパターンを提案 |
-| skill | coverage-gap-detect | テスト未カバーのパスを特定 |
-| subagent | test-runner | テスト実行（xcodebuild test）+ 結果パース |
-| subagent | coverage-reporter | カバレッジ収集 + レポート生成 |
-| skill (manual) | test-gen | テスト生成 → 実行 → カバレッジ一括ワークフロー |
-
-#### 5. `github-workflow` — Issue / PR 管理
-
-構造化された issue 作成と、差分解析に基づく PR 作成でチームのタスク管理を標準化する。
-
-| 種別 | 名前 | 内容 |
-|---|---|---|
-| skill (manual) | issue-create | 構造化された issue 作成 |
-| skill | issue-triage | ラベル・優先度・アサイン提案 |
-| skill (manual) | pr-create | 差分解析 + 説明文生成 + PR 作成 |
-| skill | pr-checklist | セルフレビューチェックリスト |
-| skill (manual) | pr-link-issues | PR と issue の紐付け |
-
-#### 6. `code-review-assist` — コードレビュー支援
-
-PR の差分を分析し、レビューコメントの生成・アーキテクチャ適合チェック・影響範囲の特定を行う。
-
-| 種別 | 名前 | 内容 |
-|---|---|---|
-| skill | pr-diff-review | PR 差分を読んでレビューコメント生成 |
-| skill | architecture-conformance | 変更が MVVM / レイヤー規約に沿っているか検査 |
-| skill | impact-analysis | 変更の影響範囲を特定（依存先・呼び出し元） |
-| skill | review-comment-draft | 指摘コメントを「理由 + 提案」形式で下書き |
-| subagent | review-analyzer | PR 全体を包括分析（大規模差分の隔離実行） |
-| skill (manual) | pr-review | 上記を組み合わせた包括レビューワークフロー |
+| 1 | [ios-architecture](plugins/ios-architecture/) | MVVM 構造チェック・レイヤー依存検査・DI 提案 |
+| 2 | [team-conventions](plugins/team-conventions/) | コーディング規約・命名規則の自動検査・強制 |
+| 3 | [swift-code-quality](plugins/swift-code-quality/) | SwiftLint / SwiftFormat による静的解析・構文チェック |
+| 4 | [swift-testing](plugins/swift-testing/) | テスト生成・実行・カバレッジ分析 |
+| 5 | [github-workflow](plugins/github-workflow/) | 構造化 Issue 作成・差分解析 PR 作成 |
+| 6 | [code-review-assist](plugins/code-review-assist/) | PR 差分分析・レビューコメント生成・影響範囲特定 |
 
 ### Tier 2: プロジェクト構築・配信フェーズで使うもの
 
-#### 7. `ios-onboarding` — オンボーディング支援
-
-プロジェクト構造の自動解説・用語集生成・最近の変更要約で、新メンバーの立ち上がりを加速する。
-
-| 種別 | 名前 | 内容 |
+| # | プラグイン | 概要 |
 |---|---|---|
-| skill | codebase-overview | プロジェクト構造の概要を自動生成 |
-| skill | module-guide | 各 SPM モジュールの責務と依存関係を解説 |
-| skill | architecture-map | アーキテクチャ構造をテキスト図で可視化 |
-| skill | glossary-gen | プロジェクト固有の用語集を生成 |
-| skill | recent-changes-summary | 直近のコミットから「今何が起きているか」を要約 |
-| subagent | codebase-analyzer | プロジェクト全体を走査して構造分析 |
-| skill (manual) | onboard | 新メンバー向けガイド一式生成ワークフロー |
+| 7 | [ios-onboarding](plugins/ios-onboarding/) | プロジェクト構造解説・用語集生成・変更要約 |
+| 8 | [feature-module-gen](plugins/feature-module-gen/) | SwiftUI + MVVM Feature Module 雛形一式生成 |
+| 9 | [ios-distribution](plugins/ios-distribution/) | アーカイブビルド・TestFlight アップロード自動化 |
 
-#### 8. `feature-module-gen` — Feature Module 生成
-
-SwiftUI + MVVM の Feature Module 雛形を一式生成し、SPM パッケージへの組み込みまで行う。新機能開発の立ち上げ。
-
-| 種別 | 名前 | 内容 |
-|---|---|---|
-| skill | feature-scaffold | Feature Module 雛形（View / ViewModel / Repository / DI）一式生成 |
-| skill | view-gen | SwiftUI View 生成（チーム規約準拠） |
-| skill | viewmodel-gen | ViewModel 生成（Input / Output, @Published 等） |
-| skill | repository-gen | Repository + Protocol 生成 |
-| skill | usecase-gen | UseCase 生成 |
-| subagent | module-generator | モジュール一式生成 + Package.swift 更新 + 構文検証 |
-| skill (manual) | new-feature | 対話的に Feature Module 一式生成ワークフロー |
-
-#### 9. `ios-distribution` — TestFlight 配信・署名
-
-アーカイブビルドから TestFlight アップロードまでの配信フローを自動化する。
-
-| 種別 | 名前 | 内容 |
-|---|---|---|
-| skill | signing-check | 署名・プロビジョニング確認 |
-| skill (manual) | build-archive | IPA 生成 |
-| skill (manual) | testflight-upload | archive + upload（xcodebuild + xcrun altool） |
-| subagent | archive-runner | アーカイブ + アップロード（隔離実行） |
-
-## subagent 一覧
-
-| subagent | 所属プラグイン | 隔離理由 |
-|---|---|---|
-| architecture-scanner | ios-architecture | 依存関係の全体分析 |
-| convention-scanner | team-conventions | プロジェクト全体の規約スキャン |
-| lint-scanner | swift-code-quality | 全体 lint 一括スキャン |
-| test-runner | swift-testing | テスト実行 + ログパース |
-| coverage-reporter | swift-testing | カバレッジ収集 + レポート |
-| review-analyzer | code-review-assist | 大規模 PR 差分の全体分析 |
-| codebase-analyzer | ios-onboarding | 全体構造の走査 + 分析 |
-| module-generator | feature-module-gen | モジュール一式生成 + 構文検証 |
-| archive-runner | ios-distribution | アーカイブ + アップロード |
-
-## ディレクトリ構成
-
-```
-ios-claude-plugins/
-├── .claude-plugin/
-│   └── marketplace.json          # マーケットプレイス定義
-├── plugins/
-│   ├── ios-architecture/          # 1. 設計ガード
-│   │   ├── .claude-plugin/
-│   │   │   └── plugin.json
-│   │   ├── skills/
-│   │   │   ├── mvvm-check/
-│   │   │   │   └── SKILL.md
-│   │   │   ├── layer-dependency-check/
-│   │   │   ├── di-pattern-suggest/
-│   │   │   ├── protocol-oriented-check/
-│   │   │   └── arch-audit/        # workflow (manual)
-│   │   └── agents/
-│   │       └── architecture-scanner.md
-│   ├── team-conventions/          # 2. 規約エンフォース
-│   ├── swift-code-quality/        # 3. 品質チェック
-│   ├── swift-testing/             # 4. テスト
-│   ├── github-workflow/           # 5. Issue / PR
-│   ├── code-review-assist/        # 6. レビュー
-│   ├── ios-onboarding/            # 7. オンボーディング
-│   ├── feature-module-gen/        # 8. モジュール生成
-│   └── ios-distribution/          # 9. 配信
-├── CLAUDE.md
-└── README.md
-```
+各プラグインの詳細（スキル一覧・subagent・hooks）は各ディレクトリの README.md を参照。
 
 ## インストール
 

--- a/plugins/code-review-assist/README.md
+++ b/plugins/code-review-assist/README.md
@@ -1,0 +1,19 @@
+# code-review-assist — コードレビュー支援
+
+PR の差分を分析し、レビューコメントの生成・アーキテクチャ適合チェック・影響範囲の特定を行う。
+
+## スキル一覧
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | pr-diff-review | PR 差分を読んでレビューコメント生成 |
+| skill | architecture-conformance | 変更が MVVM / レイヤー規約に沿っているか検査 |
+| skill | impact-analysis | 変更の影響範囲を特定（依存先・呼び出し元） |
+| skill | review-comment-draft | 指摘コメントを「理由 + 提案」形式で下書き |
+| skill (manual) | pr-review | 上記を組み合わせた包括レビューワークフロー |
+
+## subagent
+
+| 名前 | 内容 |
+|---|---|
+| review-analyzer | PR 全体を包括分析（大規模差分の隔離実行） |

--- a/plugins/feature-module-gen/README.md
+++ b/plugins/feature-module-gen/README.md
@@ -1,0 +1,20 @@
+# feature-module-gen — Feature Module 生成
+
+SwiftUI + MVVM の Feature Module 雛形を一式生成し、SPM パッケージへの組み込みまで行う。新機能開発の立ち上げ。
+
+## スキル一覧
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | feature-scaffold | Feature Module 雛形（View / ViewModel / Repository / DI）一式生成 |
+| skill | view-gen | SwiftUI View 生成（チーム規約準拠） |
+| skill | viewmodel-gen | ViewModel 生成（@Observable ベース） |
+| skill | repository-gen | Repository + Protocol 生成 |
+| skill | usecase-gen | UseCase 生成 |
+| skill (manual) | new-feature | 対話的に Feature Module 一式生成ワークフロー |
+
+## subagent
+
+| 名前 | 内容 |
+|---|---|
+| module-generator | モジュール一式生成 + Package.swift 更新 + 構文検証 |

--- a/plugins/github-workflow/README.md
+++ b/plugins/github-workflow/README.md
@@ -1,0 +1,13 @@
+# github-workflow — Issue / PR 管理
+
+構造化された issue 作成と、差分解析に基づく PR 作成でチームのタスク管理を標準化する。
+
+## スキル一覧
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill (manual) | issue-create | 構造化された issue 作成 |
+| skill | issue-triage | ラベル・優先度・アサイン提案 |
+| skill (manual) | pr-create | 差分解析 + 説明文生成 + PR 作成 |
+| skill | pr-checklist | セルフレビューチェックリスト |
+| skill (manual) | pr-link-issues | PR と issue の紐付け |

--- a/plugins/ios-architecture/README.md
+++ b/plugins/ios-architecture/README.md
@@ -1,0 +1,20 @@
+# ios-architecture — アーキテクチャガード
+
+MVVM パターンの構造チェック・レイヤー間の依存方向検査・DI パターンの提案を行う。
+
+## スキル一覧
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | mvvm-check | View / ViewModel / Model 分離の検査 |
+| skill | layer-dependency-check | レイヤー間の依存方向チェック |
+| skill | di-pattern-suggest | Dependency Injection パターンの提案 |
+| skill | protocol-oriented-check | Protocol 指向設計の推奨・改善提案 |
+| skill | concurrency-check | Swift Concurrency の安全性検査（Swift 6.2+） |
+| skill (manual) | arch-audit | アーキテクチャ全体監査ワークフロー |
+
+## subagent
+
+| 名前 | 内容 |
+|---|---|
+| architecture-scanner | 全モジュールの依存関係分析 |

--- a/plugins/ios-distribution/README.md
+++ b/plugins/ios-distribution/README.md
@@ -1,0 +1,17 @@
+# ios-distribution — TestFlight 配信・署名
+
+アーカイブビルドから TestFlight アップロードまでの配信フローを自動化する。
+
+## スキル一覧
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | signing-check | 署名・プロビジョニング確認 |
+| skill (manual) | build-archive | IPA 生成 |
+| skill (manual) | testflight-upload | archive + upload（xcodebuild + xcrun altool） |
+
+## subagent
+
+| 名前 | 内容 |
+|---|---|
+| archive-runner | アーカイブ + アップロード（隔離実行） |

--- a/plugins/ios-onboarding/README.md
+++ b/plugins/ios-onboarding/README.md
@@ -1,0 +1,20 @@
+# ios-onboarding — オンボーディング支援
+
+プロジェクト構造の自動解説・用語集生成・最近の変更要約で、新メンバーの立ち上がりを加速する。
+
+## スキル一覧
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | codebase-overview | プロジェクト構造の概要を自動生成 |
+| skill | module-guide | 各 SPM モジュールの責務と依存関係を解説 |
+| skill | architecture-map | アーキテクチャ構造をテキスト図で可視化 |
+| skill | glossary-gen | プロジェクト固有の用語集を生成 |
+| skill | recent-changes-summary | 直近のコミットから「今何が起きているか」を要約 |
+| skill (manual) | onboard | 新メンバー向けガイド一式生成ワークフロー |
+
+## subagent
+
+| 名前 | 内容 |
+|---|---|
+| codebase-analyzer | プロジェクト全体を走査して構造分析 |

--- a/plugins/swift-code-quality/README.md
+++ b/plugins/swift-code-quality/README.md
@@ -1,0 +1,21 @@
+# swift-code-quality — コード品質ガード
+
+SwiftLint / SwiftFormat による静的解析と軽量な構文チェックで、フルビルドなしにコード品質を担保する。
+
+## スキル一覧
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | swift-lint | SwiftLint 実行 + 違反の自動修正 |
+| skill | swift-format | SwiftFormat 実行 |
+| skill | syntax-typecheck | `swiftc -typecheck` による軽量構文チェック |
+| skill | complexity-analysis | 循環的複雑度・関数行数の分析 |
+| skill | dead-code-detect | 未使用コード・未使用 import の検出 |
+| skill | type-safety-check | force unwrap / force cast の検出 + 安全な書き換え提案 |
+| skill (manual) | quality-check | lint + format + typecheck 一括ワークフロー |
+
+## subagent
+
+| 名前 | 内容 |
+|---|---|
+| lint-scanner | プロジェクト全体の lint 一括スキャン |

--- a/plugins/swift-testing/README.md
+++ b/plugins/swift-testing/README.md
@@ -1,0 +1,21 @@
+# swift-testing — テスト生成・実行
+
+ユニットテスト・UI テストの生成からテスト実行・カバレッジ分析まで、テストのライフサイクル全体をサポートする。
+
+## スキル一覧
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | unit-test-gen | 対象コードからユニットテスト生成 |
+| skill | ui-test-gen | SwiftUI 画面から XCUITest 生成 |
+| skill | mock-gen | Protocol 準拠のモック / スタブ自動生成 |
+| skill | test-pattern-suggest | テスト対象に適切なテストパターンを提案 |
+| skill | coverage-gap-detect | テスト未カバーのパスを特定 |
+| skill (manual) | test-gen | テスト生成 → 実行 → カバレッジ一括ワークフロー |
+
+## subagent
+
+| 名前 | 内容 |
+|---|---|
+| test-runner | テスト実行（xcodebuild test）+ 結果パース |
+| coverage-reporter | カバレッジ収集 + レポート生成 |

--- a/plugins/team-conventions/README.md
+++ b/plugins/team-conventions/README.md
@@ -1,0 +1,27 @@
+# team-conventions — 規約エンフォーサー
+
+チームのコーディング規約・命名規則・ブランチ運用ルールを自動で検査・強制する。
+hooks でコード生成前に規約を注入し、最初から規約通りに書く。
+
+## スキル一覧
+
+| 種別 | 名前 | 内容 |
+|---|---|---|
+| skill | naming-check | Swift 命名規則（API Design Guidelines 準拠）チェック |
+| skill | file-structure-check | ファイル配置がチーム規約に沿っているか検査 |
+| skill | commit-message-lint | コミットメッセージ形式チェック |
+| skill | branch-naming-check | ブランチ命名規則の検証 |
+| skill | pr-description-gen | PR テンプレートに基づく説明文の自動生成 |
+| skill (manual) | convention-check | 変更ファイルに対する規約チェック一括ワークフロー |
+
+## subagent
+
+| 名前 | 内容 |
+|---|---|
+| convention-scanner | プロジェクト全体の規約準拠スキャン |
+
+## hooks
+
+| イベント | 内容 |
+|---|---|
+| UserPromptSubmit | コード生成時に規約をコンテキスト注入 |


### PR DESCRIPTION
## Summary
- 全 9 プラグインに `plugins/<plugin-name>/README.md` を追加
- ルート README.md のプラグイン一覧を簡素化（名前+概要1行+リンク）
- スキル・subagent・hooks の詳細は各プラグインの README.md に移動
- `feature-module-gen` の `viewmodel-gen` 説明を `@Observable` ベースに修正

closes #28

## Test plan
- [ ] 各プラグインディレクトリに README.md が存在する
- [ ] ルート README.md から各プラグインへのリンクが有効
- [ ] 情報の欠落がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)