### PR TITLE
fix: 全プラグインの plugin.json を公式スキーマに準拠させる

### DIFF
--- a/plugins/code-review-assist/.claude-plugin/plugin.json
+++ b/plugins/code-review-assist/.claude-plugin/plugin.json
@@ -2,14 +2,6 @@
   "name": "code-review-assist",
   "version": "0.1.0",
   "description": "PR の差分を分析し、レビューコメントの生成・アーキテクチャ適合チェック・影響範囲の特定を行う",
-  "skills": [
-    "skills/pr-diff-review",
-    "skills/architecture-conformance",
-    "skills/impact-analysis",
-    "skills/review-comment-draft",
-    "skills/pr-review"
-  ],
-  "agents": [
-    "agents/review-analyzer.md"
-  ]
+  "skills": "./skills/",
+  "agents": "./agents/"
 }

--- a/plugins/feature-implementation/.claude-plugin/plugin.json
+++ b/plugins/feature-implementation/.claude-plugin/plugin.json
@@ -2,13 +2,6 @@
   "name": "feature-implementation",
   "version": "0.1.0",
   "description": "要件定義書・詳細設計書・タスクリストを先に作成し、スペック駆動でフィーチャーを実装する",
-  "skills": [
-    "skills/requirements-gen",
-    "skills/design-gen",
-    "skills/task-gen",
-    "skills/implement-feature"
-  ],
-  "agents": [
-    "agents/codebase-scanner.md"
-  ]
+  "skills": "./skills/",
+  "agents": "./agents/"
 }

--- a/plugins/feature-module-gen/.claude-plugin/plugin.json
+++ b/plugins/feature-module-gen/.claude-plugin/plugin.json
@@ -2,15 +2,6 @@
   "name": "feature-module-gen",
   "version": "0.1.0",
   "description": "SwiftUI + MVVM の Feature Module 雛形を一式生成し、SPM パッケージへの組み込みまで行う",
-  "skills": [
-    "skills/feature-scaffold",
-    "skills/view-gen",
-    "skills/viewmodel-gen",
-    "skills/repository-gen",
-    "skills/usecase-gen",
-    "skills/new-feature"
-  ],
-  "agents": [
-    "agents/module-generator.md"
-  ]
+  "skills": "./skills/",
+  "agents": "./agents/"
 }

--- a/plugins/github-workflow/.claude-plugin/plugin.json
+++ b/plugins/github-workflow/.claude-plugin/plugin.json
@@ -2,11 +2,5 @@
   "name": "github-workflow",
   "version": "0.1.0",
   "description": "構造化された issue 作成と、差分解析に基づく PR 作成でチームのタスク管理を標準化する",
-  "skills": [
-    "skills/issue-create",
-    "skills/issue-triage",
-    "skills/pr-create",
-    "skills/pr-checklist",
-    "skills/pr-link-issues"
-  ]
+  "skills": "./skills/"
 }

--- a/plugins/ios-architecture/.claude-plugin/plugin.json
+++ b/plugins/ios-architecture/.claude-plugin/plugin.json
@@ -2,15 +2,6 @@
   "name": "ios-architecture",
   "version": "0.1.0",
   "description": "MVVM パターンの構造チェック・レイヤー間の依存方向検査・DI パターンの提案を行う",
-  "skills": [
-    "skills/mvvm-check",
-    "skills/layer-dependency-check",
-    "skills/di-pattern-suggest",
-    "skills/protocol-oriented-check",
-    "skills/concurrency-check",
-    "skills/arch-audit"
-  ],
-  "agents": [
-    "agents/architecture-scanner.md"
-  ]
+  "skills": "./skills/",
+  "agents": "./agents/"
 }

--- a/plugins/ios-distribution/.claude-plugin/plugin.json
+++ b/plugins/ios-distribution/.claude-plugin/plugin.json
@@ -2,12 +2,6 @@
   "name": "ios-distribution",
   "version": "0.1.0",
   "description": "アーカイブビルドから TestFlight アップロードまでの配信フローを自動化する",
-  "skills": [
-    "skills/signing-check",
-    "skills/build-archive",
-    "skills/testflight-upload"
-  ],
-  "agents": [
-    "agents/archive-runner.md"
-  ]
+  "skills": "./skills/",
+  "agents": "./agents/"
 }

--- a/plugins/ios-onboarding/.claude-plugin/plugin.json
+++ b/plugins/ios-onboarding/.claude-plugin/plugin.json
@@ -2,15 +2,6 @@
   "name": "ios-onboarding",
   "version": "0.1.0",
   "description": "プロジェクト構造の自動解説・用語集生成・最近の変更要約で、新メンバーの立ち上がりを加速する",
-  "skills": [
-    "skills/codebase-overview",
-    "skills/module-guide",
-    "skills/architecture-map",
-    "skills/glossary-gen",
-    "skills/recent-changes-summary",
-    "skills/onboard"
-  ],
-  "agents": [
-    "agents/codebase-analyzer.md"
-  ]
+  "skills": "./skills/",
+  "agents": "./agents/"
 }

--- a/plugins/swift-code-quality/.claude-plugin/plugin.json
+++ b/plugins/swift-code-quality/.claude-plugin/plugin.json
@@ -2,16 +2,6 @@
   "name": "swift-code-quality",
   "version": "0.1.0",
   "description": "SwiftLint / SwiftFormat による静的解析と軽量な構文チェックで、フルビルドなしにコード品質を担保する",
-  "skills": [
-    "skills/swift-lint",
-    "skills/swift-format",
-    "skills/syntax-typecheck",
-    "skills/complexity-analysis",
-    "skills/dead-code-detect",
-    "skills/type-safety-check",
-    "skills/quality-check"
-  ],
-  "agents": [
-    "agents/lint-scanner.md"
-  ]
+  "skills": "./skills/",
+  "agents": "./agents/"
 }

--- a/plugins/swift-testing/.claude-plugin/plugin.json
+++ b/plugins/swift-testing/.claude-plugin/plugin.json
@@ -2,16 +2,6 @@
   "name": "swift-testing",
   "version": "0.1.0",
   "description": "ユニットテスト・UI テストの生成からテスト実行・カバレッジ分析まで、テストのライフサイクル全体をサポートする",
-  "skills": [
-    "skills/unit-test-gen",
-    "skills/ui-test-gen",
-    "skills/mock-gen",
-    "skills/test-pattern-suggest",
-    "skills/coverage-gap-detect",
-    "skills/test-gen"
-  ],
-  "agents": [
-    "agents/test-runner.md",
-    "agents/coverage-reporter.md"
-  ]
+  "skills": "./skills/",
+  "agents": "./agents/"
 }

--- a/plugins/team-conventions/.claude-plugin/plugin.json
+++ b/plugins/team-conventions/.claude-plugin/plugin.json
@@ -2,18 +2,7 @@
   "name": "team-conventions",
   "version": "0.1.0",
   "description": "チームのコーディング規約・命名規則・ブランチ運用ルールを自動で検査・強制する",
-  "skills": [
-    "skills/naming-check",
-    "skills/file-structure-check",
-    "skills/commit-message-lint",
-    "skills/branch-naming-check",
-    "skills/pr-description-gen",
-    "skills/convention-check"
-  ],
-  "agents": [
-    "agents/convention-scanner.md"
-  ],
-  "hooks": [
-    "hooks/hooks.json"
-  ]
+  "skills": "./skills/",
+  "agents": "./agents/",
+  "hooks": "./hooks/hooks.json"
 }

--- a/plugins/team-conventions/hooks/hooks.json
+++ b/plugins/team-conventions/hooks/hooks.json
@@ -1,7 +1,14 @@
-[
-  {
-    "event": "UserPromptSubmit",
-    "script": "hooks/inject-conventions.sh",
-    "description": "コード生成時にチームの規約をコンテキストとして注入する"
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/inject-conventions.sh"
+          }
+        ]
+      }
+    ]
   }
-]
+}


### PR DESCRIPTION
## Summary

- 全 10 プラグインの `plugin.json` で `skills`, `agents`, `hooks` フィールドを公式スキーマに準拠する形式に修正
- `team-conventions` の `hooks.json` をイベント名キーのオブジェクト形式に修正

## 変更内容

| Before | After |
|---|---|
| `"skills": ["skills/xxx", ...]` | `"skills": "./skills/"` |
| `"agents": ["agents/xxx.md"]` | `"agents": "./agents/"` |
| `"hooks": ["hooks/hooks.json"]` | `"hooks": "./hooks/hooks.json"` |
| hooks.json: 配列形式 | hooks.json: `{ "hooks": { "EventName": [...] } }` |

Closes #33

## Test plan

- [x] 全 10 プラグインのバリデーション PASS
- [x] hooks.json のスキーマ検証 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)