### PR TITLE
fix: plugin.json の skills/agents を正しいスキーマに修正

### DIFF
--- a/plugins/code-review-assist/.claude-plugin/plugin.json
+++ b/plugins/code-review-assist/.claude-plugin/plugin.json
@@ -3,5 +3,7 @@
   "version": "0.1.0",
   "description": "PR の差分を分析し、レビューコメントの生成・アーキテクチャ適合チェック・影響範囲の特定を行う",
   "skills": "./skills/",
-  "agents": "./agents/"
+  "agents": [
+    "./agents/review-analyzer.md"
+  ]
 }

--- a/plugins/feature-implementation/.claude-plugin/plugin.json
+++ b/plugins/feature-implementation/.claude-plugin/plugin.json
@@ -3,5 +3,7 @@
   "version": "0.1.0",
   "description": "要件定義書・詳細設計書・タスクリストを先に作成し、スペック駆動でフィーチャーを実装する",
   "skills": "./skills/",
-  "agents": "./agents/"
+  "agents": [
+    "./agents/codebase-scanner.md"
+  ]
 }

--- a/plugins/feature-module-gen/.claude-plugin/plugin.json
+++ b/plugins/feature-module-gen/.claude-plugin/plugin.json
@@ -3,5 +3,7 @@
   "version": "0.1.0",
   "description": "SwiftUI + MVVM の Feature Module 雛形を一式生成し、SPM パッケージへの組み込みまで行う",
   "skills": "./skills/",
-  "agents": "./agents/"
+  "agents": [
+    "./agents/module-generator.md"
+  ]
 }

--- a/plugins/ios-architecture/.claude-plugin/plugin.json
+++ b/plugins/ios-architecture/.claude-plugin/plugin.json
@@ -3,5 +3,7 @@
   "version": "0.1.0",
   "description": "MVVM パターンの構造チェック・レイヤー間の依存方向検査・DI パターンの提案を行う",
   "skills": "./skills/",
-  "agents": "./agents/"
+  "agents": [
+    "./agents/architecture-scanner.md"
+  ]
 }

--- a/plugins/ios-distribution/.claude-plugin/plugin.json
+++ b/plugins/ios-distribution/.claude-plugin/plugin.json
@@ -3,5 +3,7 @@
   "version": "0.1.0",
   "description": "アーカイブビルドから TestFlight アップロードまでの配信フローを自動化する",
   "skills": "./skills/",
-  "agents": "./agents/"
+  "agents": [
+    "./agents/archive-runner.md"
+  ]
 }

--- a/plugins/ios-onboarding/.claude-plugin/plugin.json
+++ b/plugins/ios-onboarding/.claude-plugin/plugin.json
@@ -3,5 +3,7 @@
   "version": "0.1.0",
   "description": "プロジェクト構造の自動解説・用語集生成・最近の変更要約で、新メンバーの立ち上がりを加速する",
   "skills": "./skills/",
-  "agents": "./agents/"
+  "agents": [
+    "./agents/codebase-analyzer.md"
+  ]
 }

--- a/plugins/swift-code-quality/.claude-plugin/plugin.json
+++ b/plugins/swift-code-quality/.claude-plugin/plugin.json
@@ -3,5 +3,7 @@
   "version": "0.1.0",
   "description": "SwiftLint / SwiftFormat による静的解析と軽量な構文チェックで、フルビルドなしにコード品質を担保する",
   "skills": "./skills/",
-  "agents": "./agents/"
+  "agents": [
+    "./agents/lint-scanner.md"
+  ]
 }

--- a/plugins/swift-testing/.claude-plugin/plugin.json
+++ b/plugins/swift-testing/.claude-plugin/plugin.json
@@ -3,5 +3,8 @@
   "version": "0.1.0",
   "description": "ユニットテスト・UI テストの生成からテスト実行・カバレッジ分析まで、テストのライフサイクル全体をサポートする",
   "skills": "./skills/",
-  "agents": "./agents/"
+  "agents": [
+    "./agents/coverage-reporter.md",
+    "./agents/test-runner.md"
+  ]
 }

--- a/plugins/team-conventions/.claude-plugin/plugin.json
+++ b/plugins/team-conventions/.claude-plugin/plugin.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "description": "チームのコーディング規約・命名規則・ブランチ運用ルールを自動で検査・強制する",
   "skills": "./skills/",
-  "agents": "./agents/",
+  "agents": [
+    "./agents/convention-scanner.md"
+  ],
   "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
## Summary

- 全プラグインの `plugin.json` で `skills` を `"./skills/"` (ディレクトリパス文字列)、`agents` を `["./agents/xxx.md"]` (ファイルパス文字列配列) に統一
- `claude --plugin-dir` での動作確認済み

## Test plan

- [x] `claude --plugin-dir plugins/feature-implementation -p "hello"` でエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)